### PR TITLE
Drop support for Python 3.9, 3.10, 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = {text = "MIT"}
 authors = [
     {name = "Michael MacFerrin", email = "michael.macferrin@colorado.edu"},
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.12"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Under [SPEC 0](https://scientific-python.org/specs/spec-0000/), the oldest version we should support is 3.12!
Globato, Fetchez, Transformez all support Python >=3.12