### PR TITLE
Add linting with pre-commit/prek

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+ci:
+  autoupdate_schedule: quarterly
+  autofix_prs: false
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: forbid-new-submodules
+      - id: end-of-file-fixer
+      - id: check-case-conflict
+      - id: requirements-txt-fixer
+      - id: check-added-large-files
+        args: ['--maxkb=500']
+      - id: check-json
+      - id: check-toml
+      - id: check-yaml
+      - id: debug-statements
+      - id: check-builtin-literals
+      - id: trailing-whitespace
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.9
+    hooks:
+      - id: ruff-check
+        args: ['--fix']
+      - id: ruff-format


### PR DESCRIPTION
Resolves #8 . Ruff!

To run linting tasks automatically as a pre-commit hook, [install prek](https://prek.j178.dev/installation/) then run `prek install` from your local clone of this repo.

To run these checks in CI, we should enable pre-commit.ci. This should work automatically once we transfer this repository to continuous-dems. We should just do that.

TODO: 

- Merge #16 
- Run formatter
- Run linter autofixes and disable remaining rules with violations. We can enable them later.