### PR TITLE
Fix icesat2_vertical_datum config being silently ignored by globato

### DIFF
--- a/src/ivert/icesat2_database_v2.py
+++ b/src/ivert/icesat2_database_v2.py
@@ -380,6 +380,50 @@ class IS2Database:
         """Map a validated vertical_datum value to its vertical EPSG code string."""
         return "EPSG:4979" if vertical_datum == "ellipsoid" else "EPSG:3855"
 
+    # Maps IVERT's internal vertical-datum EPSG codes to the literal strings
+    # globato.read()'s vertical_datum kwarg accepts. globato silently falls back
+    # to "ellipsoid" for any value it doesn't recognize (it does not raise), so
+    # passing an EPSG code straight through would be a silent no-op rather than
+    # an error -- always go through this lookup instead.
+    _EPSG_TO_GLOBATO_VERTICAL_DATUM = {
+        "EPSG:4979": "ellipsoid",
+        "EPSG:3855": "geoid",
+    }
+
+    # Kept separately from the mapping above so a divergence between the two
+    # (e.g. if globato's ICESat2Reader changes its accepted vocabulary) is
+    # caught explicitly rather than silently mis-mapped.
+    _GLOBATO_ACCEPTED_VERTICAL_DATUMS = frozenset(
+        {"ellipsoid", "ellipsoid-mean-tide", "geoid", "geoid-mean-tide"}
+    )
+
+    @classmethod
+    def _vertical_epsg_to_globato_datum(cls, vertical_epsg: str) -> str:
+        """Map an IVERT vertical-datum EPSG code to the literal globato.read() expects.
+
+        Raises ValueError if the EPSG code has no known mapping, or if the mapped
+        value isn't one globato's ICESat2Reader currently accepts.
+        """
+        try:
+            globato_datum = cls._EPSG_TO_GLOBATO_VERTICAL_DATUM[vertical_epsg]
+        except KeyError:
+            raise ValueError(
+                f"No globato vertical_datum mapping for {vertical_epsg!r}. "
+                "Known mappings: "
+                f"{cls._EPSG_TO_GLOBATO_VERTICAL_DATUM}."
+            ) from None
+
+        if globato_datum not in cls._GLOBATO_ACCEPTED_VERTICAL_DATUMS:
+            raise ValueError(
+                f"Mapped globato vertical_datum {globato_datum!r} (from "
+                f"{vertical_epsg!r}) is not one of globato's accepted values "
+                f"{sorted(cls._GLOBATO_ACCEPTED_VERTICAL_DATUMS)}. globato's "
+                "ICESat2Reader may have changed its accepted vertical_datum "
+                "vocabulary; update _EPSG_TO_GLOBATO_VERTICAL_DATUM / "
+                "_GLOBATO_ACCEPTED_VERTICAL_DATUMS to match."
+            )
+        return globato_datum
+
     def _process_h5_to_nc(
         self,
         h5_fn: str,
@@ -415,7 +459,7 @@ class IS2Database:
             data_type="ATL03",
             region=region_str,
             classes=classes_str,
-            vertical_datum=vertical_datum,
+            vertical_datum=self._vertical_epsg_to_globato_datum(vertical_datum),
             reject_failed_qa=True,
             append_atl24=True,
             cache_dir=self.icesat2_download_dir,


### PR DESCRIPTION
## Summary
- `_process_h5_to_nc()` passed an EPSG code string (`"EPSG:4979"`/`"EPSG:3855"`) as globato.read()'s `vertical_datum` kwarg.
- globato's `ICESat2Reader` only recognizes the literal strings `"ellipsoid"`, `"ellipsoid-mean-tide"`, `"geoid"`, `"geoid-mean-tide"`, and silently falls back to `"ellipsoid"` for anything else instead of raising.
- Net effect: IVERT's `icesat2_vertical_datum` config setting had no effect on the heights globato actually produced — you always got ellipsoid heights back, regardless of what was configured, while the database/granule metadata could still claim `EPSG:3855` (geoid) if that's what was requested.

Found while tracking down a separate bug (continuous-dems/globato#127) where bathy_floor photon heights came out geoid-referenced regardless of requested datum — that turned out to be a different bug inside globato itself, but investigating it surfaced this one in IVERT's own call site.

## Fix
- Added `_EPSG_TO_GLOBATO_VERTICAL_DATUM`, an explicit lookup from IVERT's EPSG-code representation to globato's accepted literal strings.
- Added `_vertical_epsg_to_globato_datum()`, which does the lookup and raises `ValueError` if the EPSG code has no known mapping, or if the mapped literal isn't one globato's reader currently accepts (checked against `_GLOBATO_ACCEPTED_VERTICAL_DATUMS`, kept separate so a future change to globato's vocabulary is caught explicitly instead of silently mis-mapping again).
- `_process_h5_to_nc()` now calls this at the `globato.read()` call site instead of passing the EPSG string straight through. The EPSG-code representation is unchanged everywhere else (config validation, database/granule metadata storage).