### PR TITLE
Add -ow/--overwrite and -ex/--exclude flags to ivert validate

### DIFF
--- a/src/ivert/cli.py
+++ b/src/ivert/cli.py
@@ -822,6 +822,7 @@ def _run_validate(
     outdir=None,
     ndv=None,
     export_formats=None,
+    overwrite=False,
 ):
     """Branch to validate_dem or validate_list_of_dems based on the number of input files."""
     verbose = logging.getLogger().level <= logging.INFO
@@ -904,6 +905,7 @@ def _run_validate(
             min_confidence_level=confidence_level,
             min_bathy_confidence=bathy_confidence,
             verbose=verbose,
+            overwrite=overwrite,
         )
         if vdatum != "NONE_PROVIDED":
             kwargs["dem_vertical_datum"] = vdatum
@@ -936,6 +938,7 @@ def _run_validate(
             min_confidence_level=confidence_level,
             min_bathy_confidence=bathy_confidence,
             verbose=verbose,
+            overwrite=overwrite,
         )
         if vdatum != "NONE_PROVIDED":
             kwargs["input_vdatum"] = vdatum
@@ -1094,6 +1097,17 @@ def _run_validate(
         "for this run only. Pass 'none' (or an empty string) to skip error exports."
     ),
 )
+@click.option(
+    "-ow",
+    "--overwrite",
+    is_flag=True,
+    default=False,
+    help=(
+        "Redo the validation and overwrite existing output files, even if the "
+        "validation has already completed (or partially completed) for this DEM. "
+        "Default: reuse existing interim/output files and skip work that's already done."
+    ),
+)
 def validate(
     files_or_directory,
     vdatum,
@@ -1109,6 +1123,7 @@ def validate(
     outdir,
     ndv,
     export_formats,
+    overwrite,
 ):
     """Validate one or more DEMs against ICESat-2 photon data.
 
@@ -1152,6 +1167,7 @@ def validate(
         outdir,
         ndv=ndv,
         export_formats=export_formats,
+        overwrite=overwrite,
     )
 
 

--- a/src/ivert/cli.py
+++ b/src/ivert/cli.py
@@ -807,6 +807,35 @@ def cache_delete(force):
 # validate
 ###############################################################
 
+_EXCLUDE_VECTOR_EXTENSIONS = (".shp", ".geojson", ".gpkg")
+
+
+def _parse_exclude_spec(value):
+    """Parse a single -ex/--exclude value into a (minx, miny, maxx, maxy) tuple or a file path.
+
+    Accepts either a 4-value slash-separated bounding box ("minx/miny/maxx/maxy"), in the
+    DEM's own horizontal CRS, or a path to a .shp/.geojson/.gpkg vector file of polygons.
+    """
+    parts = value.split("/")
+    if len(parts) == 4:
+        try:
+            return tuple(float(p) for p in parts)
+        except ValueError:
+            pass
+
+    if not os.path.exists(value):
+        raise click.ClickException(
+            f"Invalid --exclude value '{value}': not a 4-value bounding box "
+            "(minx/miny/maxx/maxy) and not an existing file path."
+        )
+    ext = os.path.splitext(value)[1].lower()
+    if ext not in _EXCLUDE_VECTOR_EXTENSIONS:
+        raise click.ClickException(
+            f"Invalid --exclude file '{value}': expected one of "
+            f"{', '.join(_EXCLUDE_VECTOR_EXTENSIONS)}."
+        )
+    return value
+
 
 def _run_validate(
     files_or_directory,
@@ -823,6 +852,7 @@ def _run_validate(
     ndv=None,
     export_formats=None,
     overwrite=False,
+    exclude_zones=None,
 ):
     """Branch to validate_dem or validate_list_of_dems based on the number of input files."""
     verbose = logging.getLogger().level <= logging.INFO
@@ -913,6 +943,8 @@ def _run_validate(
             kwargs["dem_ndv"] = ndv_float
         if export_error_formats is not None:
             kwargs["export_error_formats"] = export_error_formats
+        if exclude_zones:
+            kwargs["exclude_zones"] = exclude_zones
         vd_module.validate_dem(**kwargs)
     else:
         dem_input = expanded[0] if len(expanded) == 1 else expanded
@@ -946,6 +978,8 @@ def _run_validate(
             kwargs["dem_ndv"] = ndv_float
         if export_error_formats is not None:
             kwargs["export_error_formats"] = export_error_formats
+        if exclude_zones:
+            kwargs["exclude_zones"] = exclude_zones
         vdc_module.validate_list_of_dems(**kwargs)
 
 
@@ -1108,6 +1142,19 @@ def _run_validate(
         "Default: reuse existing interim/output files and skip work that's already done."
     ),
 )
+@click.option(
+    "-ex",
+    "--exclude",
+    "exclude",
+    multiple=True,
+    metavar="BBOX_OR_FILE",
+    help=(
+        "Exclude ICESat-2 photons falling within a zone before validation. Repeatable "
+        "(use multiple times to combine zones). Each use takes either a 4-value "
+        "slash-separated bounding box in the DEM's own projection (minx/miny/maxx/maxy), "
+        "or a path to a vector file (.shp, .geojson, .gpkg) containing exclusion polygon(s)."
+    ),
+)
 def validate(
     files_or_directory,
     vdatum,
@@ -1124,6 +1171,7 @@ def validate(
     ndv,
     export_formats,
     overwrite,
+    exclude,
 ):
     """Validate one or more DEMs against ICESat-2 photon data.
 
@@ -1153,6 +1201,10 @@ def validate(
     if not files_or_directory:
         raise click.UsageError("Missing argument 'FILES_OR_DIRECTORY'.")
 
+    exclude_zones = (
+        [_parse_exclude_spec(value) for value in exclude] if exclude else None
+    )
+
     _run_validate(
         files_or_directory,
         vdatum,
@@ -1168,6 +1220,7 @@ def validate(
         ndv=ndv,
         export_formats=export_formats,
         overwrite=overwrite,
+        exclude_zones=exclude_zones,
     )
 
 

--- a/src/ivert/validate_dem.py
+++ b/src/ivert/validate_dem.py
@@ -8,6 +8,7 @@ Created on Tue Jun 22 16:06:21 2021
 
 import argparse
 import ast
+import geopandas
 import multiprocessing as mp
 import multiprocessing.shared_memory as shared_memory
 import numexpr
@@ -15,7 +16,10 @@ import numpy
 from osgeo import gdal, ogr, osr
 import os
 import pandas
+import pyproj
 import re
+import shapely
+import shapely.geometry
 import signal
 import sys
 import time
@@ -488,6 +492,7 @@ def validate_dem(
     min_confidence_level: int = 4,
     min_bathy_confidence: float = 0.90,
     export_error_formats: str | list | None = None,
+    exclude_zones: list | None = None,
     verbose: bool = True,
 ):
     """Validate a DEM and produce output results.
@@ -530,6 +535,11 @@ def validate_dem(
         export_error_formats (str, list, None): GIS formats to export the per-cell errors into,
             as a comma-separated string or list drawn from 'tif', 'gpkg', 'shp', 'xyz'. Defaults
             to None, which uses the 'export_error_formats' config value.
+        exclude_zones (list, None): Zones to exclude ICESat-2 photons from before validation.
+            Each item is either a 4-value (minx, miny, maxx, maxy) bounding box in the DEM's own
+            horizontal CRS, or a path to a vector file (.shp, .geojson, .gpkg) containing exclusion
+            polygon(s) in any CRS. Photons falling within any zone are dropped. Defaults to None
+            (no exclusions).
         verbose (bool): Be verbose.
     """
     if shared_ret_values is None:
@@ -564,6 +574,7 @@ def validate_dem(
         "min_confidence_level": min_confidence_level,
         "min_bathy_confidence": min_bathy_confidence,
         "export_error_formats": export_error_formats,
+        "exclude_zones": exclude_zones,
         "verbose": verbose,
     }
 
@@ -649,6 +660,7 @@ def validate_dem(
                 numprocs=numprocs,
                 min_confidence_level=min_confidence_level,
                 min_bathy_confidence=min_bathy_confidence,
+                exclude_zones=exclude_zones,
                 verbose=verbose,
                 max_subdivides=max_subdivides,
                 orig_dem_name=orig_dem_name,
@@ -1109,6 +1121,33 @@ def _fetch_photons(
     return dem_ds, dem_array, photon_df, dem_epsg_str, photon_src_epsg
 
 
+def _resolve_exclude_geometry(exclude_zones, dem_epsg_str):
+    """Resolve exclude-zone specs into a single shapely geometry in the DEM's horizontal CRS.
+
+    Each item in exclude_zones is either a 4-value (minx, miny, maxx, maxy) bounding box
+    already in the DEM's horizontal CRS, or a path to a vector file (.shp, .geojson, .gpkg)
+    containing polygon(s) in any CRS, which get reprojected into the DEM's horizontal CRS.
+
+    Returns a single (possibly multi-part) shapely geometry, or None if exclude_zones is empty.
+    """
+    dem_horz_crs = dem_geom.get_dem_reference_frame_from_user_input(dem_epsg_str, "h")
+
+    geoms = []
+    for zone in exclude_zones:
+        if isinstance(zone, (list, tuple)):
+            minx, miny, maxx, maxy = zone
+            geoms.append(shapely.geometry.box(minx, miny, maxx, maxy))
+        else:
+            gdf = geopandas.read_file(zone)
+            if gdf.crs is not None and not pyproj.CRS(gdf.crs).equals(dem_horz_crs):
+                gdf = gdf.to_crs(dem_horz_crs)
+            geoms.extend(geom for geom in gdf.geometry if geom is not None)
+
+    if not geoms:
+        return None
+    return shapely.unary_union(geoms)
+
+
 def _compute_photon_overlap(
     dem_ds,
     dem_array,
@@ -1120,6 +1159,7 @@ def _compute_photon_overlap(
     photon_src_epsg="EPSG:4326+4979",
     cache_dir=None,
     user_ndv=None,
+    exclude_zones=None,
 ):
     """Transform photon coordinates into DEM space and compute cell-level overlap.
 
@@ -1141,6 +1181,23 @@ def _compute_photon_overlap(
     except (ValueError, RuntimeError) as e:
         print("Warning: Unable to perform transformation. Using original points.")
         raise e
+
+    if exclude_zones:
+        exclude_geom = _resolve_exclude_geometry(exclude_zones, dem_epsg_str)
+        if exclude_geom is not None:
+            excluded_mask = (
+                geopandas.GeoSeries(
+                    geopandas.points_from_xy(photon_df["dem_x"], photon_df["dem_y"])
+                )
+                .within(exclude_geom)
+                .to_numpy()
+            )
+            if verbose and excluded_mask.any():
+                print(
+                    "{:,}".format(numpy.count_nonzero(excluded_mask)),
+                    "photons excluded by exclusion zone(s).",
+                )
+            photon_df = photon_df[~excluded_mask]
 
     xstart, xstep, _, ystart, _, ystep = dem_ds.GetGeoTransform()
     photon_df["i"] = numpy.floor((photon_df["dem_y"] - ystart) / ystep).astype(int)
@@ -1731,6 +1788,7 @@ def validate_dem_parallel(
     min_confidence_level: int = 4,
     min_bathy_confidence: float = 0.90,
     export_error_formats: str | list | None = None,
+    exclude_zones: list | None = None,
     verbose: bool = True,
 ):
     """Validate a single DEM.
@@ -1822,6 +1880,7 @@ def validate_dem_parallel(
         photon_src_epsg=photon_src_epsg,
         cache_dir=TRANSFORMEZ_CACHE_DIR,
         user_ndv=dem_ndv,
+        exclude_zones=exclude_zones,
     )
     if overlap_result is None:
         if mark_empty_results:

--- a/src/ivert/validate_dem_collection.py
+++ b/src/ivert/validate_dem_collection.py
@@ -111,6 +111,7 @@ def validate_list_of_dems(
     min_confidence_level: int = 1,
     min_bathy_confidence: float = 0.75,
     export_error_formats: str | list | None = None,
+    exclude_zones: list | None = None,
     verbose: bool = True,
 ):
     """Take a list of DEMs, presumably in a single area, and output validation files for those DEMs.
@@ -344,6 +345,7 @@ def validate_list_of_dems(
                 min_confidence_level=min_confidence_level,
                 min_bathy_confidence=min_bathy_confidence,
                 export_error_formats=export_error_formats,
+                exclude_zones=exclude_zones,
                 verbose=verbose,
             )
         except MemoryError:


### PR DESCRIPTION
## Summary
- `-ow/--overwrite`: force `ivert validate` to redo a validation and overwrite existing output files, even if a prior run already completed (or partially completed) for that DEM. Exposes the `overwrite` parameter that already existed in `validate_dem()`/`validate_list_of_dems()`.
- `-ex/--exclude`: repeatable flag to exclude ICESat-2 photons within a zone before validation. Each use takes either a `minx/miny/maxx/maxy` bounding box in the DEM's own projection, or a path to a vector file (`.shp`, `.geojson`, `.gpkg`) containing exclusion polygon(s) in any CRS, reprojected automatically into the DEM's CRS. Useful for masking out known-bad ICESat-2 data found during validation.

## Test plan
- [x] `ivert validate --help` shows both new flags with correct help text
- [x] `-ow`/`-ex` parsing verified: bbox parsing, invalid bbox/file rejection, vector-file reading, polygon+bbox union, and CRS reprojection (WGS84 file -> UTM DEM CRS) all confirmed with synthetic data
- [x] `ruff check` and `ruff format` pass
- [x] End-to-end validation run against a real DEM with an exclude zone (not run in this environment)