### PR TITLE
Port remaining standalone-script argparse parsers to click

### DIFF
--- a/src/ivert/export_vector.py
+++ b/src/ivert/export_vector.py
@@ -23,11 +23,11 @@ Examples
     python ivert_output_vector.py granules/ --merge -o merged_bahamas.gpkg
 """
 
-import argparse
 import glob
 import os
 import sys
 
+import click
 import geopandas
 import netCDF4
 import numpy as np
@@ -170,82 +170,73 @@ def collect_nc_files(paths: list) -> list:
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
-def define_and_parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description="Convert IVERT ICESat-2 .nc granule files to GIS vector formats.",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog=__doc__,
-    )
-    parser.add_argument(
-        "inputs",
-        nargs="+",
-        help=".nc file(s) or director(y/ies) containing .nc files.",
-    )
-    parser.add_argument(
-        "-of",
-        "--output_format",
-        dest="output_format",
-        default="gpkg",
-        choices=list(SUPPORTED_FORMATS.keys()),
-        help="Output format. Default: gpkg",
-    )
-    parser.add_argument(
-        "-d",
-        "--output_dir",
-        dest="output_dir",
-        default=None,
-        help="Output directory. Default: same directory as each input file.",
-    )
-    parser.add_argument(
-        "-o",
-        "--output",
-        dest="output",
-        default=None,
-        help="Explicit output filename (only valid with --merge or a single input).",
-    )
-    parser.add_argument(
-        "--merge",
-        action="store_true",
-        default=False,
-        help="Merge all input granules into a single output file.",
-    )
-    parser.add_argument(
-        "--classes",
-        default=None,
-        help="Comma-separated class codes to include (e.g. '1,40,41'). "
-        "Default: all classes.",
-    )
-    parser.add_argument(
-        "-w",
-        "--overwrite",
-        action="store_true",
-        default=False,
-        help="Overwrite existing output files.",
-    )
-    return parser.parse_args()
+@click.command(
+    help="Convert IVERT ICESat-2 .nc granule files to GIS vector formats.",
+    epilog=__doc__,
+)
+@click.argument("inputs", nargs=-1, required=True)
+@click.option(
+    "-of",
+    "--output_format",
+    default="gpkg",
+    type=click.Choice(list(SUPPORTED_FORMATS.keys())),
+    help="Output format. Default: gpkg",
+)
+@click.option(
+    "-d",
+    "--output_dir",
+    default=None,
+    help="Output directory. Default: same directory as each input file.",
+)
+@click.option(
+    "-o",
+    "--output",
+    default=None,
+    help="Explicit output filename (only valid with --merge or a single input).",
+)
+@click.option(
+    "--merge",
+    is_flag=True,
+    default=False,
+    help="Merge all input granules into a single output file.",
+)
+@click.option(
+    "--classes",
+    "classes_str",
+    default=None,
+    help="Comma-separated class codes to include (e.g. '1,40,41'). "
+    "Default: all classes.",
+)
+@click.option(
+    "-w",
+    "--overwrite",
+    is_flag=True,
+    default=False,
+    help="Overwrite existing output files.",
+)
+def main(inputs, output_format, output_dir, output, merge, classes_str, overwrite):
+    """Convert IVERT ICESat-2 .nc granule files to GIS vector formats.
 
-
-def main():
-    args = define_and_parse_args()
-
-    fmt_key = args.output_format.lower().lstrip(".")
+    INPUTS is one or more .nc file(s) or director(y/ies) containing .nc files.
+    """
+    fmt_key = output_format.lower().lstrip(".")
     _, ext = SUPPORTED_FORMATS[fmt_key]
 
     classes = None
-    if args.classes:
-        classes = [int(c.strip()) for c in args.classes.split(",")]
+    if classes_str:
+        classes = [int(c.strip()) for c in classes_str.split(",")]
 
-    nc_files = collect_nc_files(args.inputs)
+    nc_files = collect_nc_files(list(inputs))
     if not nc_files:
         sys.exit("No .nc files found.")
 
-    if args.output_dir and not os.path.isdir(args.output_dir):
-        sys.exit(f"Output directory does not exist: {args.output_dir}")
+    if output_dir and not os.path.isdir(output_dir):
+        sys.exit(f"Output directory does not exist: {output_dir}")
 
     # ------------------------------------------------------------------
     # Merged mode: combine all granules into one output file
     # ------------------------------------------------------------------
-    if args.merge:
+    if merge:
         gdfs = []
         for nc_path in nc_files:
             print(f"Reading {os.path.basename(nc_path)} ...", flush=True)
@@ -261,19 +252,19 @@ def main():
             crs=WGS84_EPSG,
         )
 
-        if args.output:
-            outpath = args.output
+        if output:
+            outpath = output
         else:
-            outdir = args.output_dir or os.path.dirname(nc_files[0])
+            outdir = output_dir or os.path.dirname(nc_files[0])
             outpath = os.path.join(outdir, "merged" + ext)
 
-        write_vector(merged, outpath, fmt_key, overwrite=args.overwrite)
+        write_vector(merged, outpath, fmt_key, overwrite=overwrite)
         return
 
     # ------------------------------------------------------------------
     # Per-file mode
     # ------------------------------------------------------------------
-    if args.output and len(nc_files) > 1:
+    if output and len(nc_files) > 1:
         sys.exit("--output requires exactly one input file (or use --merge).")
 
     for nc_path in nc_files:
@@ -281,14 +272,14 @@ def main():
         gdf = nc_to_geodataframe(nc_path, classes=classes)
         print(f"  {len(gdf):,} photons")
 
-        if args.output:
-            outpath = args.output
+        if output:
+            outpath = output
         else:
             stem = os.path.splitext(os.path.basename(nc_path))[0]
-            outdir = args.output_dir or os.path.dirname(nc_path)
+            outdir = output_dir or os.path.dirname(nc_path)
             outpath = os.path.join(outdir, stem + ext)
 
-        write_vector(gdf, outpath, fmt_key, overwrite=args.overwrite)
+        write_vector(gdf, outpath, fmt_key, overwrite=overwrite)
 
 
 if __name__ == "__main__":

--- a/src/ivert/icesat2_database_v2.py
+++ b/src/ivert/icesat2_database_v2.py
@@ -1604,7 +1604,7 @@ def split_bbox_into_parts(
     return bboxes
 
 
-def _cmd_list(args):
+def _cmd_list():
     """Implementation of the 'list' subcommand."""
     import tabulate as tabulate_mod
 
@@ -1632,7 +1632,7 @@ def _cmd_list(args):
     print(f"\n{len(gdf)} granule(s)  —  db: {db.db_fname}")
 
 
-def _cmd_delete(args):
+def _cmd_delete(delete_all):
     """Implementation of the 'delete' subcommand."""
     db = IS2Database()
 
@@ -1643,7 +1643,7 @@ def _cmd_delete(args):
         else:
             print(f"Not found (skipping): {fpath}")
 
-    if args.all:
+    if delete_all:
         nc_files = (
             [
                 os.path.join(db.granules_dir, fn)
@@ -1661,7 +1661,7 @@ def _cmd_delete(args):
             print(f"No .nc files found in {db.granules_dir}")
 
 
-def _cmd_rebuild(args):
+def _cmd_rebuild():
     """Implementation of the 'rebuild' subcommand."""
     db = IS2Database()
     gdf = db.create_new_database(populate=True, overwrite=True)
@@ -1669,33 +1669,36 @@ def _cmd_rebuild(args):
 
 
 if __name__ == "__main__":
-    import argparse
+    import click
 
-    parser = argparse.ArgumentParser(
-        prog="icesat2_database_v2",
-        description="Manage the local ICESat-2 photon granule database.",
+    @click.group(
+        name="icesat2_database_v2",
+        help="Manage the local ICESat-2 photon granule database.",
     )
-    sub = parser.add_subparsers(dest="command", metavar="COMMAND")
-    sub.required = True
+    def _cli():
+        pass
 
-    list_p = sub.add_parser("list", help="List granules currently in the database.")
-    list_p.set_defaults(func=_cmd_list)
+    @_cli.command("list", help="List granules currently in the database.")
+    def _list_command():
+        _cmd_list()
 
-    delete_p = sub.add_parser(
-        "delete", help="Delete the .gpkg and .blosc database files."
+    @_cli.command("delete", help="Delete the .gpkg and .blosc database files.")
+    @click.option(
+        "--all",
+        "delete_all",
+        is_flag=True,
+        help="Also delete all .nc granule data files.",
     )
-    delete_p.add_argument(
-        "--all", action="store_true", help="Also delete all .nc granule data files."
-    )
-    delete_p.set_defaults(func=_cmd_delete)
+    def _delete_command(delete_all):
+        _cmd_delete(delete_all)
 
-    rebuild_p = sub.add_parser(
+    @_cli.command(
         "rebuild",
         help="Rebuild the database from existing .nc granule files."
         "Useful if the .nc files have been modified at all, and/or if you suspect"
         " the overview information has become inaccurate.",
     )
-    rebuild_p.set_defaults(func=_cmd_rebuild)
+    def _rebuild_command():
+        _cmd_rebuild()
 
-    parsed = parser.parse_args()
-    parsed.func(parsed)
+    _cli()

--- a/src/ivert/plot_photon_clouds_v2.py
+++ b/src/ivert/plot_photon_clouds_v2.py
@@ -19,11 +19,11 @@ Class codes (current convention):
     41 = bathy surface (water surface)
 """
 
-import argparse
 import os
 import glob
 import sys
 
+import click
 import numpy as np
 import pandas as pd
 import matplotlib
@@ -440,106 +440,127 @@ def plot_beam(
     print(f"  Saved {outpath}")
 
 
-def main():
-    parser = argparse.ArgumentParser(
-        description="Plot classified ICESat-2 photon curtains."
-    )
-    parser.add_argument(
-        "input_file",
-        help="Path to the .nc granule file, or an ATL03 .h5 file "
-        "(automatically enables --h5-only).",
-    )
-    parser.add_argument(
-        "--laser",
-        "-b",
-        default=None,
-        help="Laser/beam to plot (e.g. gt2l). Default: plot all beams.",
-    )
-    parser.add_argument(
-        "--outdir",
-        "-o",
-        default=None,
-        help="Output directory for images (default: same dir as input file).",
-    )
-    parser.add_argument(
-        "--zmin",
-        type=float,
-        default=None,
-        help="Minimum elevation to display (m). Data outside [-1e5, 1e5] is "
-        "always filtered regardless.",
-    )
-    parser.add_argument(
-        "--zmax", type=float, default=None, help="Maximum elevation to display (m)."
-    )
-    parser.add_argument(
-        "--xmin",
-        type=float,
-        default=None,
-        help="Minimum along-track distance to display (km).",
-    )
-    parser.add_argument(
-        "--xmax",
-        type=float,
-        default=None,
-        help="Maximum along-track distance to display (km).",
-    )
-    parser.add_argument(
-        "--classes",
-        default=None,
-        help="Slash-separated class codes to highlight (e.g. '1/40/41'). "
-        "Photons not in the list are reclassified as noise and shown "
-        "in grey. Default: show all classes. Pass '' to show all "
-        "photons as noise.",
-    )
-    parser.add_argument(
-        "--h5",
-        nargs="?",
-        const=True,
-        default=None,
-        help="ATL03 .h5 file to use as noise background. Supply a path, or "
-        "omit the path to search the IVERT cache for a file whose name "
-        "starts with the same granule ID as the .nc file.",
-    )
-    parser.add_argument(
-        "--h5-only",
-        action="store_true",
-        default=False,
-        help="Plot only the ATL03 .h5 photons (all as noise); ignore the "
-        ".nc classifications entirely. Automatically enabled when the "
-        "input file is an .h5.",
-    )
-    parser.add_argument(
-        "--dem",
-        nargs="+",
-        default=None,
-        metavar="DEM",
-        help="One or more DEM raster files to profile along the laser track. "
-        "Each overlapping DEM is plotted as a line at its sampled elevations.",
-    )
-    parser.add_argument(
-        "--vdatum",
-        "-V",
-        default=None,
-        help="Target vertical datum for photons and DEMs (e.g. 'navd88', "
-        "'egm2008', 'EPSG:5703'). Transforms ICESat-2 photons from "
-        "EGM2008 and DEM elevations to the given datum so both are "
-        "on the same vertical reference. Default: EGM2008 (no transform).",
-    )
-    args = parser.parse_args()
+# Sentinel flag_value for --h5 given without a path.
+_H5_SEARCH_CACHE = "__SEARCH_CACHE__"
+
+
+@click.command(help="Plot classified ICESat-2 photon curtains.")
+@click.argument("input_file")
+@click.option(
+    "--laser",
+    "-b",
+    default=None,
+    help="Laser/beam to plot (e.g. gt2l). Default: plot all beams.",
+)
+@click.option(
+    "--outdir",
+    "-o",
+    default=None,
+    help="Output directory for images (default: same dir as input file).",
+)
+@click.option(
+    "--zmin",
+    type=float,
+    default=None,
+    help="Minimum elevation to display (m). Data outside [-1e5, 1e5] is "
+    "always filtered regardless.",
+)
+@click.option(
+    "--zmax", type=float, default=None, help="Maximum elevation to display (m)."
+)
+@click.option(
+    "--xmin",
+    type=float,
+    default=None,
+    help="Minimum along-track distance to display (km).",
+)
+@click.option(
+    "--xmax",
+    type=float,
+    default=None,
+    help="Maximum along-track distance to display (km).",
+)
+@click.option(
+    "--classes",
+    "classes_str",
+    default=None,
+    help="Slash-separated class codes to highlight (e.g. '1/40/41'). "
+    "Photons not in the list are reclassified as noise and shown "
+    "in grey. Default: show all classes. Pass '' to show all "
+    "photons as noise.",
+)
+@click.option(
+    "--h5",
+    "h5_arg",
+    is_flag=False,
+    flag_value=_H5_SEARCH_CACHE,
+    default=None,
+    help="ATL03 .h5 file to use as noise background. Supply a path, or "
+    "omit the path to search the IVERT cache for a file whose name "
+    "starts with the same granule ID as the .nc file.",
+)
+@click.option(
+    "--h5-only",
+    is_flag=True,
+    default=False,
+    help="Plot only the ATL03 .h5 photons (all as noise); ignore the "
+    ".nc classifications entirely. Automatically enabled when the "
+    "input file is an .h5.",
+)
+@click.option(
+    "--dem",
+    multiple=True,
+    metavar="DEM",
+    help="A DEM raster file to profile along the laser track. May be given "
+    "multiple times. Each overlapping DEM is plotted as a line at its "
+    "sampled elevations.",
+)
+@click.option(
+    "--vdatum",
+    "-V",
+    default=None,
+    help="Target vertical datum for photons and DEMs (e.g. 'navd88', "
+    "'egm2008', 'EPSG:5703'). Transforms ICESat-2 photons from "
+    "EGM2008 and DEM elevations to the given datum so both are "
+    "on the same vertical reference. Default: EGM2008 (no transform).",
+)
+def main(
+    input_file,
+    laser,
+    outdir,
+    zmin,
+    zmax,
+    xmin,
+    xmax,
+    classes_str,
+    h5_arg,
+    h5_only,
+    dem,
+    vdatum,
+):
+    """Plot classified ICESat-2 photon curtains.
+
+    INPUT_FILE is the path to the .nc granule file, or an ATL03 .h5 file
+    (automatically enables --h5-only).
+    """
+    # --h5 is tri-state: True means "search the cache", a string is an
+    # explicit path, None means the option was absent.
+    h5_arg = True if h5_arg == _H5_SEARCH_CACHE else h5_arg
+    dem = list(dem) if dem else None
 
     # Resolve vertical datum --------------------------------------------------
     target_vert_epsg_int = None
     ylabel = "Elevation / depth (m, EGM2008 geoid)"
-    if args.vdatum:
+    if vdatum:
         import ivert.vdatum_lookup
 
         try:
-            vdatum_str = ivert.vdatum_lookup.resolve_vdatum(args.vdatum)
+            vdatum_str = ivert.vdatum_lookup.resolve_vdatum(vdatum)
         except ImportError:
-            vdatum_str = args.vdatum if ":" in args.vdatum else f"EPSG:{args.vdatum}"
+            vdatum_str = vdatum if ":" in vdatum else f"EPSG:{vdatum}"
         if vdatum_str is None:
             sys.exit(
-                f"Unknown vertical datum: {args.vdatum!r}. "
+                f"Unknown vertical datum: {vdatum!r}. "
                 "Use an EPSG code or common name (e.g. 'navd88', 'egm2008')."
             )
         try:
@@ -556,38 +577,38 @@ def main():
     except Exception:
         cache_dir = None
 
-    input_path = os.path.abspath(args.input_file)
+    input_path = os.path.abspath(input_file)
     if not os.path.exists(input_path):
         sys.exit(f"File not found: {input_path}")
 
     zlim = None
-    if args.zmin is not None or args.zmax is not None:
-        zlim = (args.zmin, args.zmax)
+    if zmin is not None or zmax is not None:
+        zlim = (zmin, zmax)
 
     dlim = None
-    if args.xmin is not None or args.xmax is not None:
-        dlim = (args.xmin, args.xmax)
+    if xmin is not None or xmax is not None:
+        dlim = (xmin, xmax)
 
-    if args.classes is None:
+    if classes_str is None:
         classes = None
-    elif args.classes == "":
+    elif classes_str == "":
         classes = set()
     else:
-        classes = {int(c) for c in args.classes.split("/")}
+        classes = {int(c) for c in classes_str.split("/")}
 
     # ------------------------------------------------------------------ h5-only
-    h5_only = args.h5_only or input_path.lower().endswith(".h5")
+    h5_only = h5_only or input_path.lower().endswith(".h5")
 
     if h5_only:
         # Resolve the h5 file to use
         if input_path.lower().endswith(".h5"):
             h5_path = input_path
-        elif args.h5 is True:
+        elif h5_arg is True:
             h5_path = _find_h5(input_path)
             if h5_path is None:
                 sys.exit("--h5-only: no matching .h5 found in cache.")
-        elif args.h5:
-            h5_path = os.path.abspath(args.h5)
+        elif h5_arg:
+            h5_path = os.path.abspath(h5_arg)
             if not os.path.exists(h5_path):
                 sys.exit(f".h5 file not found: {h5_path}")
         else:
@@ -595,13 +616,13 @@ def main():
             if h5_path is None:
                 sys.exit("--h5-only: no matching .h5 found in cache.")
 
-        outdir = args.outdir or os.path.dirname(h5_path)
+        outdir = outdir or os.path.dirname(h5_path)
         os.makedirs(outdir, exist_ok=True)
         h5_stem = os.path.splitext(os.path.basename(h5_path))[0]
 
         print(f"H5-only: {os.path.basename(h5_path)}", flush=True)
         beam_dts = _beam_delta_times(h5_path)
-        beams_to_plot = [args.laser] if args.laser else list(beam_dts.keys())
+        beams_to_plot = [laser] if laser else list(beam_dts.keys())
 
         for beam in beams_to_plot:
             if beam not in beam_dts:
@@ -616,7 +637,7 @@ def main():
                 df_plot = _apply_vdatum_to_df(df_plot, target_vert_epsg_int, cache_dir)
             _dlons, _dlats, _datm = _positions_for_dem_sampling(df_plot, dlim)
             dem_profiles = _collect_dem_profiles(
-                args.dem, _dlons, _dlats, _datm, target_vert_epsg_int, cache_dir
+                dem, _dlons, _dlats, _datm, target_vert_epsg_int, cache_dir
             )
             outpath = os.path.join(outdir, f"{h5_stem}_{beam}.png")
             plot_beam(
@@ -633,7 +654,7 @@ def main():
 
     # ------------------------------------------------------------------ nc + optional h5
     nc_path = input_path
-    outdir = args.outdir or os.path.dirname(nc_path)
+    outdir = outdir or os.path.dirname(nc_path)
     os.makedirs(outdir, exist_ok=True)
 
     print(f"Loading {os.path.basename(nc_path)} ...", flush=True)
@@ -641,12 +662,12 @@ def main():
     nc_stem = os.path.splitext(os.path.basename(nc_path))[0]
 
     # Resolve .h5 path for beam splitting and noise background
-    if args.h5 is True:
+    if h5_arg is True:
         h5_path = _find_h5(nc_path)
         if h5_path is None:
             print("Warning: --h5 given but no matching .h5 found in cache.", flush=True)
-    elif args.h5:
-        h5_path = os.path.abspath(args.h5)
+    elif h5_arg:
+        h5_path = os.path.abspath(h5_arg)
         if not os.path.exists(h5_path):
             sys.exit(f".h5 file not found: {h5_path}")
     else:
@@ -655,7 +676,7 @@ def main():
     if h5_path:
         print(f"Found .h5: {os.path.basename(h5_path)}", flush=True)
         beam_dts = _beam_delta_times(h5_path)
-        beams_to_plot = [args.laser] if args.laser else list(beam_dts.keys())
+        beams_to_plot = [laser] if laser else list(beam_dts.keys())
 
         for beam in beams_to_plot:
             if beam not in beam_dts:
@@ -700,7 +721,7 @@ def main():
                 df_plot = _apply_vdatum_to_df(df_plot, target_vert_epsg_int, cache_dir)
             _dlons, _dlats, _datm = _positions_for_dem_sampling(df_plot, dlim)
             dem_profiles = _collect_dem_profiles(
-                args.dem, _dlons, _dlats, _datm, target_vert_epsg_int, cache_dir
+                dem, _dlons, _dlats, _datm, target_vert_epsg_int, cache_dir
             )
             outpath = os.path.join(outdir, f"{nc_stem}_{beam}.png")
             plot_beam(
@@ -717,7 +738,7 @@ def main():
         # No .h5 — use laser/along_track_m from the nc file directly if present.
         if "laser" in df.columns:
             beams_in_nc = sorted(df["laser"].unique())
-            beams_to_plot_noh5 = [args.laser] if args.laser else beams_in_nc
+            beams_to_plot_noh5 = [laser] if laser else beams_in_nc
             for beam in beams_to_plot_noh5:
                 df_beam = df[df["laser"] == beam].copy()
                 if df_beam.empty:
@@ -734,7 +755,7 @@ def main():
                     )
                 _dlons, _dlats, _datm = _positions_for_dem_sampling(df_beam, dlim)
                 dem_profiles = _collect_dem_profiles(
-                    args.dem, _dlons, _dlats, _datm, target_vert_epsg_int, cache_dir
+                    dem, _dlons, _dlats, _datm, target_vert_epsg_int, cache_dir
                 )
                 outpath = os.path.join(outdir, f"{nc_stem}_{beam}.png")
                 plot_beam(

--- a/src/ivert/utils/list_photon_tiles.py
+++ b/src/ivert/utils/list_photon_tiles.py
@@ -2,7 +2,7 @@
 
 import os
 
-import argparse
+import click
 
 import ivert.utils.configfile as configfile
 import ivert.s3 as s3
@@ -43,16 +43,15 @@ def write_photon_tiles_to_file(outfile: str):
     print(f"Wrote {len(fnames)} photon tiles to {outfile}.")
 
 
-def define_and_parse_args():
-    """Define and parse command line arguments."""
-    parser = argparse.ArgumentParser(
-        description="List all photon tiles in an S3 bucket and write out to a file."
-    )
-    parser.add_argument("outfile", help="The name of the output file.")
+@click.command(help="List all photon tiles in an S3 bucket and write out to a file.")
+@click.argument("outfile")
+def main(outfile):
+    """List all photon tiles in an S3 bucket and write out to a file.
 
-    return parser.parse_args()
+    OUTFILE is the name of the output file.
+    """
+    write_photon_tiles_to_file(outfile)
 
 
 if __name__ == "__main__":
-    args = define_and_parse_args()
-    write_photon_tiles_to_file(args.outfile)
+    main()

--- a/src/ivert/utils/split_dem.py
+++ b/src/ivert/utils/split_dem.py
@@ -1,12 +1,12 @@
 #!python3
 """Quick utility for splitting a large DEM into sub-segments to ease processing constraints."""
 
-import argparse
 import glob
 import itertools
 import os
 import typing
 
+import click
 import rasterio
 import rasterio.windows
 
@@ -130,33 +130,29 @@ def evenly_split(N: int, factor: int) -> list:
     return batches
 
 
-def define_and_parse_args():
-    parser = argparse.ArgumentParser(
-        description="Split a DEM into sub-segments, each side split by a factor."
-    )
-    parser.add_argument(
-        "dem_name",
-        nargs="+",
-        help="The name of the DEM file. May use bash-style glob flags (*.tif) to select multiple files.",
-    )
-    parser.add_argument(
-        "-f",
-        "--factor",
-        type=int,
-        default=2,
-        help="The factor by which to split each side of the DEM. This will create f^2 files.",
-    )
-    parser.add_argument(
-        "-o",
-        "--output_dir",
-        type=str,
-        default=None,
-        help="The directory to which the sub-segments will be written. Default: will use the same directory as the input DEM.",
-    )
+@click.command(help="Split a DEM into sub-segments, each side split by a factor.")
+@click.argument("dem_name", nargs=-1, required=True)
+@click.option(
+    "-f",
+    "--factor",
+    type=int,
+    default=2,
+    help="The factor by which to split each side of the DEM. This will create f^2 files.",
+)
+@click.option(
+    "-o",
+    "--output_dir",
+    type=str,
+    default=None,
+    help="The directory to which the sub-segments will be written. Default: will use the same directory as the input DEM.",
+)
+def main(dem_name, factor, output_dir):
+    """Split a DEM into sub-segments, each side split by a factor.
 
-    return parser.parse_args()
+    DEM_NAME is the name of the DEM file. May use bash-style glob flags (*.tif) to select multiple files.
+    """
+    split(list(dem_name), factor, output_dir)
 
 
 if __name__ == "__main__":
-    args = define_and_parse_args()
-    split(args.dem_name, args.factor, args.output_dir)
+    main()

--- a/src/ivert/utils/traverse_directory.py
+++ b/src/ivert/utils/traverse_directory.py
@@ -4,7 +4,8 @@
 
 import re
 import os
-import argparse
+
+import click
 
 
 def list_files(
@@ -49,49 +50,46 @@ def _list_files_recurse(dirname, regex_match=None, depth=-1):
     return file_list
 
 
-def define_and_parse_args():
-    parser = argparse.ArgumentParser(
-        description="A utility for recursively finding (or deleting) files in a directory and sub-directories."
-    )
-    parser.add_argument(
-        "DIR",
-        type=str,
-        default=os.getcwd(),
-        help="Directory to search within. Default: Current working directory.",
-    )
-    parser.add_argument(
-        "-text",
-        "-t",
-        type=str,
-        default=r"\A[\.\-\w]*",
-        help="Regular expression to match.",
-    )
-    parser.add_argument(
-        "-depth",
-        type=int,
-        default=-1,
-        help="Maximum directory depth to search. -1 is no limit. 0 is only the local directory. 1 or more delves that many sub-directories. Default -1.",
-    )
-    parser.add_argument(
-        "--delete",
-        "-d",
-        action="store_true",
-        default=False,
-        help="Delete the files matching the search query. NOTE: Suggest to call first without this option to see what will be deleted, then re-call with -d.",
-    )
+@click.command(
+    help="A utility for recursively finding (or deleting) files in a directory and sub-directories."
+)
+@click.argument("directory", type=str, required=False, default=None)
+@click.option(
+    "-text",
+    "-t",
+    "text",
+    type=str,
+    default=r"\A[\.\-\w]*",
+    help="Regular expression to match.",
+)
+@click.option(
+    "-depth",
+    "depth",
+    type=int,
+    default=-1,
+    help="Maximum directory depth to search. -1 is no limit. 0 is only the local directory. 1 or more delves that many sub-directories. Default -1.",
+)
+@click.option(
+    "--delete",
+    "-d",
+    is_flag=True,
+    default=False,
+    help="Delete the files matching the search query. NOTE: Suggest to call first without this option to see what will be deleted, then re-call with -d.",
+)
+def main(directory, text, depth, delete):
+    """Recursively find (or delete) files in a directory and sub-directories.
 
-    return parser.parse_args()
+    DIRECTORY is the directory to search within. Default: Current working directory.
+    """
+    if directory is None:
+        directory = os.getcwd()
 
+    fnames = list_files(directory, regex_match=text, depth=depth)
 
-if "__main__" == __name__:
-    args = define_and_parse_args()
-
-    fnames = list_files(args.DIR, regex_match=args.text, depth=args.depth)
-
-    if len(fnames) > 0 and args.delete:
+    if len(fnames) > 0 and delete:
         response = input(
             "{0} files found matching pattern '{1}' found for deletion. Do you want to proceed (y/n)? ".format(
-                len(fnames), args.text
+                len(fnames), text
             )
         )
         response = response.strip().lower()[0]
@@ -99,8 +97,12 @@ if "__main__" == __name__:
         response = None
 
     for fn in fnames:
-        if args.delete and response == "y":
+        if delete and response == "y":
             print("Removing", fn)
             os.remove(fn)
         else:
             print(fn)
+
+
+if "__main__" == __name__:
+    main()

--- a/src/ivert/validate_dem.py
+++ b/src/ivert/validate_dem.py
@@ -6,8 +6,8 @@ Created on Tue Jun 22 16:06:21 2021
 @author: mmacferrin
 """
 
-import argparse
 import ast
+import click
 import geopandas
 import multiprocessing as mp
 import multiprocessing.shared_memory as shared_memory
@@ -2232,119 +2232,126 @@ def export_error_results(
     return exported
 
 
-def read_and_parse_args():
-    # Collect and process command-line arguments.
-    parser = argparse.ArgumentParser(
-        description="Use ICESat-2 photon data to validate a DEM and generate statistics."
-    )
-    parser.add_argument("input_dem", type=str, help="The input DEM.")
-    parser.add_argument(
-        "output_dir",
-        type=str,
-        nargs="?",
-        default="",
-        help="Directory to write output results. Default: Will put in the same directory as input filename",
-    )
-    parser.add_argument(
-        "--classes",
-        "-c",
-        type=str,
-        default="1/6/40",
-        help="ICESat-2 photon classes to include in validation, separated by slashes. Default '1/6/40',"
-        "which are 'ground', 'land_ice', and 'bathy_floor'.",
-    )
-    parser.add_argument(
-        "--input_vdatum",
-        "-ivd",
-        type=str,
-        default="egm2008",
-        help="Input DEM vertical datum, as a string or 'EPSG:code'. (Default: 'egm2008')",
-    )
-    parser.add_argument(
-        "--datadir",
-        type=str,
-        default="",
-        help="A scratch directory to write interim data files. Useful if user would like to save temp files elsewhere. Defaults to the output_dir directory.",
-    )
-    parser.add_argument(
-        "--band_num",
-        type=int,
-        default=1,
-        help="The band number (1-indexed) of the input_dem. (Default: 1)",
-    )
-    parser.add_argument(
-        "--place_name",
-        "-name",
-        type=str,
-        default=None,
-        help="A text name of the location, to put in the title of the plot (if --plot_results is selected)",
-    )
-    parser.add_argument(
-        "--numprocs",
-        "-np",
-        type=int,
-        default=parallel_funcs.physical_cpu_count(),
-        help="The number of sub-processes to run for this validation. Default to the maximum physical CPU count on this machine.",
-    )
-    parser.add_argument(
-        "--delete_datafiles",
-        action="store_true",
-        default=False,
-        help="Delete the interim data files generated. Reduces storage requirements. (Default: keep them all.)",
-    )
-    parser.add_argument(
-        "--measure_coverage",
-        "-mc",
-        action="store_true",
-        default=False,
-        help="Measure the coverage %age of icesat-2 data in each of the output DEM cells.",
-    )
-    parser.add_argument(
-        "--write_result_tifs",
-        action="store_true",
-        default=False,
-        help=""""Write output geotiff with the errors in cells that have ICESat-2 photons, NDVs elsewhere.""",
-    )
-    parser.add_argument(
-        "--outlier_sd_threshold",
-        default="2.5",
-        help="Number of standard-deviations away from the mean to omit outliers. Default 2.5 (standard deviations). Choose 'None' if no outlier filtering is requested.",
-    )
-    parser.add_argument(
-        "--plot_results",
-        action="store_true",
-        default=False,
-        help="Make summary plots of the validation statistics.",
-    )
-    parser.add_argument(
-        "--overwrite",
-        action="store_true",
-        default=False,
-        help="Overwrite all interim and output files, even if they already exist. Default: Use interim files to compute results, saving time.",
-    )
-    parser.add_argument(
-        "--quiet",
-        action="store_true",
-        default=False,
-        help="Suppress output messaging, including error messages (just fail quietly without errors, return status 1).",
-    )
+@click.command(
+    help="Use ICESat-2 photon data to validate a DEM and generate statistics."
+)
+@click.argument("input_dem", type=str)
+@click.argument("output_dir", type=str, required=False, default="")
+@click.option(
+    "--classes",
+    "-c",
+    type=str,
+    default="1/6/40",
+    help="ICESat-2 photon classes to include in validation, separated by slashes. Default '1/6/40',"
+    "which are 'ground', 'land_ice', and 'bathy_floor'.",
+)
+@click.option(
+    "--input_vdatum",
+    "-ivd",
+    type=str,
+    default="egm2008",
+    help="Input DEM vertical datum, as a string or 'EPSG:code'. (Default: 'egm2008')",
+)
+@click.option(
+    "--datadir",
+    type=str,
+    default="",
+    help="A scratch directory to write interim data files. Useful if user would like to save temp files elsewhere. Defaults to the output_dir directory.",
+)
+@click.option(
+    "--band_num",
+    type=int,
+    default=1,
+    help="The band number (1-indexed) of the input_dem. (Default: 1)",
+)
+@click.option(
+    "--place_name",
+    "-name",
+    type=str,
+    default=None,
+    help="A text name of the location, to put in the title of the plot (if --plot_results is selected)",
+)
+@click.option(
+    "--numprocs",
+    "-np",
+    type=int,
+    default=parallel_funcs.physical_cpu_count(),
+    help="The number of sub-processes to run for this validation. Default to the maximum physical CPU count on this machine.",
+)
+@click.option(
+    "--delete_datafiles",
+    is_flag=True,
+    default=False,
+    help="Delete the interim data files generated. Reduces storage requirements. (Default: keep them all.)",
+)
+@click.option(
+    "--measure_coverage",
+    "-mc",
+    is_flag=True,
+    default=False,
+    help="Measure the coverage %age of icesat-2 data in each of the output DEM cells.",
+)
+@click.option(
+    "--write_result_tifs",
+    is_flag=True,
+    default=False,
+    help="Write output geotiff with the errors in cells that have ICESat-2 photons, NDVs elsewhere.",
+)
+@click.option(
+    "--outlier_sd_threshold",
+    default="2.5",
+    help="Number of standard-deviations away from the mean to omit outliers. Default 2.5 (standard deviations). Choose 'None' if no outlier filtering is requested.",
+)
+@click.option(
+    "--plot_results",
+    is_flag=True,
+    default=False,
+    help="Make summary plots of the validation statistics.",
+)
+@click.option(
+    "--overwrite",
+    is_flag=True,
+    default=False,
+    help="Overwrite all interim and output files, even if they already exist. Default: Use interim files to compute results, saving time.",
+)
+@click.option(
+    "--quiet",
+    is_flag=True,
+    default=False,
+    help="Suppress output messaging, including error messages (just fail quietly without errors, return status 1).",
+)
+def main(
+    input_dem,
+    output_dir,
+    classes,
+    input_vdatum,
+    datadir,
+    band_num,
+    place_name,
+    numprocs,
+    delete_datafiles,
+    measure_coverage,
+    write_result_tifs,
+    outlier_sd_threshold,
+    plot_results,
+    overwrite,
+    quiet,
+):
+    """Use ICESat-2 photon data to validate a DEM and generate statistics.
 
-    return parser.parse_args()
-
-
-if __name__ == "__main__":
-    args = read_and_parse_args()
-
+    INPUT_DEM is the input DEM. OUTPUT_DIR is the directory to write output
+    results; defaults to the same directory as the input filename.
+    """
     # The output directory defaults to the input directory.
-    if not args.output_dir:
-        args.output_dir = os.path.dirname(args.input_dem)
+    if not output_dir:
+        output_dir = os.path.dirname(input_dem)
 
     # The data directory defaults to the output directory.
-    if not args.datadir:
-        args.datadir = args.output_dir
+    if not datadir:
+        datadir = output_dir
 
     try:
-        classes_list = [int(c) for c in args.classes.split("/")]
+        classes_list = [int(c) for c in classes.split("/")]
     except ValueError:
         print(
             "ERROR: 'classes' must be a list of integer values separated by forward-slashes (/)"
@@ -2356,19 +2363,23 @@ if __name__ == "__main__":
 
     # Run the validation
     validate_dem(
-        args.input_dem,
-        output_dir=args.output_dir,
+        input_dem,
+        output_dir=output_dir,
         classes=classes_list,
-        dem_vertical_datum=args.input_vdatum,
-        interim_data_dir=(None if not args.datadir else args.datadir),
-        overwrite=args.overwrite,
-        delete_datafiles=args.delete_datafiles,
-        write_result_tifs=args.write_result_tifs,
-        plot_results=args.plot_results,
-        location_name=args.place_name,
-        outliers_sd_threshold=ast.literal_eval(args.outlier_sd_threshold),
-        measure_coverage=args.measure_coverage,
-        numprocs=args.numprocs,
-        band_num=args.band_num,
-        verbose=not args.quiet,
+        dem_vertical_datum=input_vdatum,
+        interim_data_dir=(None if not datadir else datadir),
+        overwrite=overwrite,
+        delete_datafiles=delete_datafiles,
+        write_result_tifs=write_result_tifs,
+        plot_results=plot_results,
+        location_name=place_name,
+        outliers_sd_threshold=ast.literal_eval(outlier_sd_threshold),
+        measure_coverage=measure_coverage,
+        numprocs=numprocs,
+        band_num=band_num,
+        verbose=not quiet,
     )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ivert/validate_dem_collection.py
+++ b/src/ivert/validate_dem_collection.py
@@ -4,8 +4,8 @@
 Code for validating and summarizing an entire list or directory of DEMs.
 """
 
-import argparse
 import ast
+import click
 import multiprocessing as mp
 import numpy
 import os
@@ -415,203 +415,190 @@ def validate_list_of_dems(
     return files_to_export
 
 
-def define_and_parse_args():
-    parser = argparse.ArgumentParser(
-        description="Tool for validating a list or directory of DEMs against ICESat-2 photon data."
-    )
+@click.command(
+    help="Tool for validating a list or directory of DEMs against ICESat-2 photon data."
+)
+@click.argument("directory_or_files", type=str, nargs=-1, required=True)
+@click.option(
+    "--fname_filter",
+    "-ff",
+    type=str,
+    default=r"\.tif\Z",
+    help=r"A regex string to search for in all DEM file names, to use as a filter. Defaults to "
+    "r'\\.tif\\Z', indicating .tif at the end of the file name. Helps elimiate files that "
+    "shouldn't be considered.",
+)
+@click.option(
+    "--fname_omit",
+    "-fo",
+    type=str,
+    default=None,
+    help="A regex string to search for and OMIT if it contains a match in the file name. Useful "
+    "for avoiding derived datasets (such as converted DEMs) in the folder.",
+)
+@click.option(
+    "--output_dir",
+    "-od",
+    type=str,
+    default=None,
+    help="Directory to output results. Default to the a sub-directory named 'icesat2' within the "
+    "input directory.",
+)
+@click.option(
+    "--input_vdatum",
+    "-ivd",
+    default="egm2008",
+    help="The vertical datum of the input DEMs. Default: 'egm2008'",
+)
+@click.option(
+    "--place_name",
+    "-name",
+    type=str,
+    default=None,
+    help="Readable name of the location being validated. Will be used in output summary plots and "
+    "validation report.",
+)
+@click.option(
+    "--overwrite",
+    "-o",
+    is_flag=True,
+    default=False,
+    help="Overwrite all files, including intermittent data files. Default: False "
+    "(skips re-computing already-computed reseults.",
+)
+@click.option(
+    "-cf",
+    "--create_folders",
+    type=yes_no.interpret_yes_no,
+    default=True,
+    help="Create folders specified in -output_dir and -data_dir, as well as the full path to "
+    "-photon_h5, if they do not already exist. Otherwise will raise errors if directories "
+    "don't already exist. Default: True.",
+)
+# @click.option("-mob", "--mask_osm_buildings",
+#               type=yes_no.interpret_yes_no, default=True,
+#               help="Whether to mask out OSM-derived building footprints in the coastline mask. "
+#                    "Must be followed by 'True', 'False', 'Yes', 'No', or any abbreviation thereof "
+#                    "(case-insensitive). (Default: True)")
+#
+# @click.option("-mbb", "--mask_bing_buildings",
+#               type=yes_no.interpret_yes_no, default=True,
+#               help="Whether to mask out Bing-derived building footprints in the coastline mask. "
+#                    "Must be followed by 'True', 'False', 'Yes', 'No', or any abbreviation thereof "
+#                    "(case-insensitive). (Default: True)")
+#
+# @click.option("-mwsf", "--mask_wsf_urban",
+#               type=yes_no.interpret_yes_no, default=False,
+#               help="Whether to mask out World-Settlement-Footprint heavy urban areas in the "
+#                    "coastline mask. Typically used instead of building footprints for coarse DEMs "
+#                    "with grid cells larger than typical buildings (~20-ish m). Must be followed by "
+#                    "'True', 'False', 'Yes', 'No', or any abbreviation thereof (case-insensitive). "
+#                    "(Default: False)")
+#
+# @click.option("-ml", "--mask_lakes",
+#               type=yes_no.interpret_yes_no, default=True,
+#               help="Whether to make out lakes, using Hydrolakes and the National Hydrologic Dataset. "
+#                    "(Default: True)")
+@click.option(
+    "-ind",
+    "--individual_results",
+    type=yes_no.interpret_yes_no,
+    default=True,
+    help="By default, a summary plot and text file are generated for the dataset. If this is "
+    "selected, they will be generated for each individual DEM as well. Files will be placed "
+    "in the -output_dir directory. Default: True",
+)
+@click.option(
+    "--include_photon_validation",
+    "-ph",
+    is_flag=True,
+    default=False,
+    help="Produce a photon database (stored in '*_photon_level_results.h5') with errors on a "
+    "photon-level (not cell-level) scale. Useful for identifying bad ICESat-2 granules.",
+)
+@click.option(
+    "--delete_datafiles",
+    "-del",
+    is_flag=True,
+    default=False,
+    help="By default, all data files generted in this process are kept. If this option is chosen, "
+    "delete them.",
+)
+@click.option(
+    "--outlier_sd_threshold",
+    default="2.5",
+    help="Number of standard-deviations away from the mean to omit outliers. Default 2.5. "
+    "May choose 'None' if no filtering is requested.",
+)
+@click.option(
+    "--measure_coverage",
+    "-mc",
+    is_flag=True,
+    default=False,
+    help="Measure the coverage %age of icesat-2 data in each of the output DEM cells.",
+)
+@click.option(
+    "-wrt",
+    "--write_result_tifs",
+    type=yes_no.interpret_yes_no,
+    default=True,
+    help="Write output geotiff with the errors in cells that have ICESat-2 photons, "
+    "NDVs elsewhere. Default: True",
+)
+@click.option(
+    "-wsc",
+    "--write_summary_csv",
+    type=yes_no.interpret_yes_no,
+    default=True,
+    help="Write a CSV with summary results of each individual DEM.",
+)
+@click.option("--quiet", "-q", is_flag=True, default=False, help="Suppress output.")
+def main(
+    directory_or_files,
+    fname_filter,
+    fname_omit,
+    output_dir,
+    input_vdatum,
+    place_name,
+    overwrite,
+    create_folders,
+    individual_results,
+    include_photon_validation,
+    delete_datafiles,
+    outlier_sd_threshold,
+    measure_coverage,
+    write_result_tifs,
+    write_summary_csv,
+    quiet,
+):
+    """Validate a list or directory of DEMs against ICESat-2 photon data.
 
-    parser.add_argument(
-        "directory_or_files",
-        type=str,
-        nargs="+",
-        help="A directory path, or a list of individual DEM tiles. Defaults to the same as the input "
-        "directory, or the directory in which the first DEM resides.",
-    )
+    DIRECTORY_OR_FILES is a directory path, or a list of individual DEM tiles.
+    """
+    directory_or_files = list(directory_or_files)
 
-    parser.add_argument(
-        "--fname_filter",
-        "-ff",
-        type=str,
-        default=r"\.tif\Z",
-        help=r"A regex string to search for in all DEM file names, to use as a filter. Defaults to "
-        "r'\\.tif\\Z', indicating .tif at the end of the file name. Helps elimiate files that "
-        "shouldn't be considered.",
-    )
-
-    parser.add_argument(
-        "--fname_omit",
-        "-fo",
-        type=str,
-        default=None,
-        help="A regex string to search for and OMIT if it contains a match in the file name. Useful "
-        "for avoiding derived datasets (such as converted DEMs) in the folder.",
-    )
-
-    parser.add_argument(
-        "--output_dir",
-        "-od",
-        type=str,
-        default=None,
-        help="Directory to output results. Default to the a sub-directory named 'icesat2' within the "
-        "input directory.",
-    )
-
-    parser.add_argument(
-        "--input_vdatum",
-        "-ivd",
-        default="egm2008",
-        help="The vertical datum of the input DEMs. Default: 'egm2008'",
-    )
-
-    parser.add_argument(
-        "--place_name",
-        "-name",
-        type=str,
-        default=None,
-        help="Readable name of the location being validated. Will be used in output summary plots and "
-        "validation report.",
-    )
-
-    parser.add_argument(
-        "--overwrite",
-        "-o",
-        action="store_true",
-        default=False,
-        help="Overwrite all files, including intermittent data files. Default: False "
-        "(skips re-computing already-computed reseults.",
-    )
-
-    parser.add_argument(
-        "-cf",
-        "--create_folders",
-        dest="create_folders",
-        type=yes_no.interpret_yes_no,
-        default=True,
-        help="Create folders specified in -output_dir and -data_dir, as well as the full path to "
-        "-photon_h5, if they do not already exist. Otherwise will raise errors if directories "
-        "don't already exist. Default: True.",
-    )
-
-    # parser.add_argument("-mob", "--mask_osm_buildings", dest="mask_osm_buildings",
-    #                     type=yes_no.interpret_yes_no, default=True,
-    #                     help="Whether to mask out OSM-derived building footprints in the coastline mask. "
-    #                          "Must be followed by 'True', 'False', 'Yes', 'No', or any abbreviation thereof "
-    #                          "(case-insensitive). (Default: True)")
-    #
-    # parser.add_argument("-mbb", "--mask_bing_buildings", dest="mask_bing_buildings",
-    #                     type=yes_no.interpret_yes_no, default=True,
-    #                     help="Whether to mask out Bing-derived building footprints in the coastline mask. "
-    #                          "Must be followed by 'True', 'False', 'Yes', 'No', or any abbreviation thereof "
-    #                          "(case-insensitive). (Default: True)")
-    #
-    # parser.add_argument("-mwsf", "--mask_wsf_urban", dest="mask_wsf_urban",
-    #                     type=yes_no.interpret_yes_no, default=False,
-    #                     help="Whether to mask out World-Settlement-Footprint heavy urban areas in the "
-    #                          "coastline mask. Typically used instead of building footprints for coarse DEMs "
-    #                          "with grid cells larger than typical buildings (~20-ish m). Must be followed by "
-    #                          "'True', 'False', 'Yes', 'No', or any abbreviation thereof (case-insensitive). "
-    #                          "(Default: False)")
-    #
-    # parser.add_argument("-ml", "--mask_lakes", dest="mask_lakes",
-    #                     type=yes_no.interpret_yes_no, default=True,
-    #                     help="Whether to make out lakes, using Hydrolakes and the National Hydrologic Dataset. "
-    #                          "(Default: True)")
-
-    parser.add_argument(
-        "-ind",
-        "--individual_results",
-        dest="individual_results",
-        type=yes_no.interpret_yes_no,
-        default=True,
-        help="By default, a summary plot and text file are generated for the dataset. If this is "
-        "selected, they will be generated for each individual DEM as well. Files will be placed "
-        "in the -output_dir directory. Default: True",
-    )
-
-    parser.add_argument(
-        "--include_photon_validation",
-        "-ph",
-        action="store_true",
-        default=False,
-        help="Produce a photon database (stored in '*_photon_level_results.h5') with errors on a "
-        "photon-level (not cell-level) scale. Useful for identifying bad ICESat-2 granules.",
-    )
-
-    parser.add_argument(
-        "--delete_datafiles",
-        "-del",
-        action="store_true",
-        default=False,
-        help="By default, all data files generted in this process are kept. If this option is chosen, "
-        "delete them.",
-    )
-
-    parser.add_argument(
-        "--outlier_sd_threshold",
-        default="2.5",
-        help="Number of standard-deviations away from the mean to omit outliers. Default 2.5. "
-        "May choose 'None' if no filtering is requested.",
-    )
-
-    parser.add_argument(
-        "--measure_coverage",
-        "-mc",
-        action="store_true",
-        default=False,
-        help="Measure the coverage %age of icesat-2 data in each of the output DEM cells.",
-    )
-
-    parser.add_argument(
-        "-wrt",
-        "--write_result_tifs",
-        dest="write_result_tifs",
-        type=yes_no.interpret_yes_no,
-        default=True,
-        help="Write output geotiff with the errors in cells that have ICESat-2 photons, "
-        "NDVs elsewhere. Default: True",
-    )
-
-    parser.add_argument(
-        "-wsc",
-        "--write_summary_csv",
-        dest="write_summary_csv",
-        type=yes_no.interpret_yes_no,
-        default=True,
-        help="Write a CSV with summary results of each individual DEM.",
-    )
-
-    parser.add_argument(
-        "--quiet", "-q", action="store_true", default=False, help="Suppress output."
-    )
-
-    return parser.parse_args()
-
-
-def main():
-    args = define_and_parse_args()
-
-    if args.output_dir is None:
+    if output_dir is None:
         # Default to data dir or directory of first data file, in the 'icesat2' sub-directory.
-        path = args.directory_or_files[0]
+        path = directory_or_files[0]
         if type(path) is str and os.path.isdir(path):
-            args.output_dir = os.path.join(path, "icesat2")
+            output_dir = os.path.join(path, "icesat2")
         else:
-            args.output_dir = os.path.join(os.path.split(path)[0], "icesat2")
+            output_dir = os.path.join(os.path.split(path)[0], "icesat2")
 
-        assert type(args.output_dir) is str
+        assert type(output_dir) is str
 
-    if (type(args.fname_filter) in (list, tuple)) and (len(args.fname_filter) == 1):
-        args.fname_filter = args.fname_filter[0]
+    if (type(fname_filter) in (list, tuple)) and (len(fname_filter) == 1):
+        fname_filter = fname_filter[0]
 
     # Check for the existence of appropriate output & data directories.
 
-    output_dir = os.path.abspath(args.output_dir)
-    if not os.path.exists(output_dir):
-        if args.create_folders:
-            os.makedirs(output_dir)
+    output_dir_abs = os.path.abspath(output_dir)
+    if not os.path.exists(output_dir_abs):
+        if create_folders:
+            os.makedirs(output_dir_abs)
         else:
             raise FileNotFoundError(
-                f"Output directory '{args.output_dir}' does not exist. "
+                f"Output directory '{output_dir}' does not exist. "
                 "Create directory or use the --create_folders flag upon execution."
             )
 
@@ -625,26 +612,26 @@ def main():
     mp.set_start_method("spawn")
 
     validate_list_of_dems(
-        args.directory_or_files,
-        fname_filter=args.fname_filter,
-        fname_omit=args.fname_omit,
-        output_dir=args.output_dir,
-        input_vdatum=args.input_vdatum,
-        overwrite=args.overwrite,
-        place_name=args.place_name,
-        create_individual_results=args.individual_results,
-        delete_datafiles=args.delete_datafiles,
-        include_photon_validation=args.include_photon_validation,
-        write_result_tifs=args.write_result_tifs,
-        # mask_osm_buildings=args.mask_osm_buildings,
-        # mask_bing_buildings=args.mask_bing_buildings,
-        # mask_wsf_urban=args.mask_wsf_urban,
-        # mask_out_lakes=args.mask_lakes,
+        directory_or_files,
+        fname_filter=fname_filter,
+        fname_omit=fname_omit,
+        output_dir=output_dir,
+        input_vdatum=input_vdatum,
+        overwrite=overwrite,
+        place_name=place_name,
+        create_individual_results=individual_results,
+        delete_datafiles=delete_datafiles,
+        include_photon_validation=include_photon_validation,
+        write_result_tifs=write_result_tifs,
+        # mask_osm_buildings=mask_osm_buildings,
+        # mask_bing_buildings=mask_bing_buildings,
+        # mask_wsf_urban=mask_wsf_urban,
+        # mask_out_lakes=mask_lakes,
         # omit_bad_granules=True,
-        measure_coverage=args.measure_coverage,
-        write_summary_csv=args.write_summary_csv,
-        outliers_sd_threshold=ast.literal_eval(args.outlier_sd_threshold),
-        verbose=not args.quiet,
+        measure_coverage=measure_coverage,
+        write_summary_csv=write_summary_csv,
+        outliers_sd_threshold=ast.literal_eval(outlier_sd_threshold),
+        verbose=not quiet,
     )
 
 


### PR DESCRIPTION
## Summary

Converts the eight remaining argparse CLIs in `src/ivert/` to click, matching the main `ivert` CLI (issue #7). These are standalone script entry points and are not wired into the main CLI.

Ported files:
- `validate_dem.py`
- `validate_dem_collection.py`
- `export_vector.py`
- `plot_photon_clouds_v2.py`
- `icesat2_database_v2.py` (argparse subparsers → click group, still defined inside `__main__`)
- `utils/split_dem.py`
- `utils/traverse_directory.py`
- `utils/list_photon_tiles.py`

No `argparse` imports remain in `src/`.

## Intentional CLI differences

- `plot_photon_clouds_v2.py`: `--dem` is now repeatable (`--dem a.tif --dem b.tif`) instead of space-separated multi-value, since click options don't support `nargs='+'`. `--h5` without a path keeps its search-the-cache behavior via a `flag_value` sentinel.
- `traverse_directory.py`: the directory argument is now genuinely optional, defaulting to the current working directory as its help text always claimed (argparse required it despite the declared default).

All other flags, defaults, and help text are unchanged.

## Notes

- `utils/list_photon_tiles.py` was already broken before this PR: it imports `ivert.s3`, which was removed with the archive directory (#37). The port compiles, but the script fails at import — candidate for deletion or repointing in a follow-up.

## Testing

- `--help` verified for all eight scripts (including the `icesat2_database_v2` subcommands)
- Functional check of `traverse_directory.py`'s single-dash flags (`-t`, `-depth`)
- prek (ruff check + format and all other hooks) passes