### PR TITLE
Cross-platform compatibility fixes for Windows and macOS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ keywords = ["Geospatial"]
 dependencies = [
     "blosc2",
     "click",
+    "colorama; platform_system == 'Windows'",
     "dateparser",
     "geopandas",
     "h5py",

--- a/src/ivert/cli.py
+++ b/src/ivert/cli.py
@@ -157,7 +157,7 @@ def _options_set_values(assignments):
         click.echo(f"  {key} = {value}")
 
     os.makedirs(os.path.dirname(user_path), exist_ok=True)
-    with open(user_path, "w") as f:
+    with open(user_path, "w", encoding="utf-8") as f:
         user_config.write(f)
 
     click.echo(f"\nSaved to {user_path}")

--- a/src/ivert/utils/bcolors.py
+++ b/src/ivert/utils/bcolors.py
@@ -1,7 +1,31 @@
-"""Quick little utility for adding colors to the command-line.
+"""Cross-platform utility for adding colors to command-line output.
 
-Source: https://svn.blender.org/svnroot/bf-blender/trunk/blender/build_files/scons/tools/bcolors.py
+The color codes below are standard ANSI escape sequences. They render natively
+on Linux and macOS terminals. On Windows they require virtual-terminal (VT)
+processing to be enabled on the console, which is off by default; colorama's
+``just_fix_windows_console()`` turns it on for modern Windows terminals
+(Windows 10+ / Windows Terminal) and is a harmless no-op on other platforms.
+
+That call only sets the console-mode flag -- it does not wrap or replace
+``sys.stdout`` -- so it does not interfere with the stdout redirection in
+``loggerproc.Logger`` (which strips these codes when writing to log files).
+
+colorama is a hard dependency on Windows (pulled in via click) and is not needed
+on Linux/macOS, so a missing import there is fine and simply left as a no-op.
+
+Original ANSI codes from:
+https://svn.blender.org/svnroot/bf-blender/trunk/blender/build_files/scons/tools/bcolors.py
 """
+
+try:
+    import colorama
+
+    # Enable ANSI/VT processing on Windows consoles. No-op on Linux/macOS.
+    colorama.just_fix_windows_console()
+except (ImportError, AttributeError):
+    # colorama absent (Linux/macOS) or too old to expose just_fix_windows_console.
+    # ANSI codes render natively on POSIX terminals, so nothing else is needed.
+    pass
 
 
 class bcolors:

--- a/src/ivert/utils/configfile.py
+++ b/src/ivert/utils/configfile.py
@@ -3,7 +3,6 @@ import configparser
 import importlib.resources
 import os
 import re
-import sys
 
 from ivert.utils import is_aws, version
 
@@ -12,6 +11,24 @@ ivert_default_configfile = str(
 )
 
 ivert_config = None
+
+
+def _is_absolute_path(value):
+    """Return True if 'value' is an absolute filesystem path on any platform.
+
+    Recognizes Unix roots ("/..."), Windows drive-letter roots ("C:\\..." or
+    "C:/..."), and UNC roots ("\\\\server\\share"), independent of the OS this is
+    running on, so config files can be resolved consistently across platforms.
+    """
+    stripped = value.strip()
+    # Unix absolute path, or a UNC path written with forward slashes ("//server").
+    if stripped.startswith("/"):
+        return True
+    # Windows UNC path ("\\server\share").
+    if stripped.startswith("\\\\"):
+        return True
+    # Windows drive-letter absolute path ("C:\..." or "C:/...").
+    return bool(re.match(r"[A-Za-z]:[\\/]", stripped))
 
 
 class Config:
@@ -179,33 +196,21 @@ class Config:
                 # This is a URL (http://, https://, ftp://, s3://, etc.). Leave it as-is.
                 pass
 
-            elif sys.platform in ("linux", "cygwin", "darwin") and value.find("/") > -1:
-                # If it's an absolute path or it already exists where it is, just use it as-is
-                if value.strip().find("/") == 0:
-                    setattr(self, key, os.path.abspath(value))
-                # If it references the home directory, expand that on the local machine.
-                elif value.find("~") > -1:
+            # Treat the value as a path if it references the home directory ('~') or
+            # contains a path separator. Both '/' and '\' are recognized regardless of
+            # platform: config files are written with forward slashes (e.g. "~/.ivert"),
+            # which are valid on Windows too, so path handling must not depend on
+            # sys.platform. os.path.expanduser resolves '~' cross-platform.
+            elif ("~" in value) or ("/" in value) or ("\\" in value):
+                # If it references the home directory, expand it on the local machine.
+                if "~" in value:
                     setattr(self, key, os.path.abspath(os.path.expanduser(value)))
-                # If it's a relative path, make it relative to the _configfile's local directory.
-                else:
-                    setattr(
-                        self,
-                        key,
-                        self._abspath(
-                            os.path.join(os.path.dirname(self._configfile), value),
-                        ),
-                    )
-                return
-
-            elif sys.platform in ("win32", "win64") and value.find("\\") > -1:
-                # If it's an absolute path or it already exists where it is, just use it as-is
-                # For a base path, look for the "C:\" drive-name pattern at the start (upper- or lower-case).
-                if re.search(r"\A[A-Za-z]:\\", value.strip()) is not None:
+                # If it's already an absolute path, just use it as-is. Recognize both
+                # Unix ("/...") and Windows ("C:\...", "C:/...", or UNC "\\...") roots
+                # so shared config files resolve correctly on either platform.
+                elif _is_absolute_path(value):
                     setattr(self, key, os.path.abspath(value))
-                # If it references the home directory, expand that on the local machine.
-                elif value.find("~") > -1:
-                    setattr(self, key, os.path.abspath(os.path.expanduser(value)))
-                # If it's a relative path, make it relative to the _configfile directory.
+                # If it's a relative path, make it relative to the _configfile's directory.
                 else:
                     setattr(
                         self,

--- a/src/ivert/utils/is_aws.py
+++ b/src/ivert/utils/is_aws.py
@@ -13,7 +13,7 @@ def is_aws():
     try:
         return (
             os.path.exists(datasource_path)
-            and "DataSourceEc2" in open(datasource_path).read()
+            and "DataSourceEc2" in open(datasource_path, encoding="utf-8").read()
         )
 
     except (NameError, FileNotFoundError):

--- a/src/ivert/utils/list_photon_tiles.py
+++ b/src/ivert/utils/list_photon_tiles.py
@@ -36,7 +36,7 @@ def write_photon_tiles_to_file(outfile: str):
             ],
         )
 
-    with open(outfile, "w") as f:
+    with open(outfile, "w", encoding="utf-8") as f:
         f.writelines(fn + "\n" for fn in fnames)
 
     print(f"Wrote {len(fnames)} photon tiles to {outfile}.")

--- a/src/ivert/utils/loggerproc.py
+++ b/src/ivert/utils/loggerproc.py
@@ -78,7 +78,7 @@ class Logger(io.TextIOWrapper):
             self.terminal_stdout = None
 
         self.filename_out = filename
-        self.log = open(self.filename_out, "a", buffering=1)
+        self.log = open(self.filename_out, "a", buffering=1, encoding="utf-8")
         # Apparently this should have a flush attribute to be compatible with stdout print(flush=True) statements.
 
     def flush(self):

--- a/src/ivert/validate_dem.py
+++ b/src/ivert/validate_dem.py
@@ -607,7 +607,12 @@ def validate_dem(
 
         return list(shared_ret_values.values())
 
-    if abs(exitcode) == abs(signal.SIGKILL):
+    # Detect a job that was killed by the operating system (on Linux, the OOM-killer
+    # sends SIGKILL, which multiprocessing reports as a negative exitcode). Windows has
+    # no SIGKILL and no equivalent OOM-killer, so guard the attribute lookup: there the
+    # branch simply doesn't apply and we fall through to the RuntimeError below.
+    sigkill = getattr(signal, "SIGKILL", None)
+    if sigkill is not None and abs(exitcode) == abs(sigkill):
         # The job was killed by the operating system. This happens with a Memory Error. Divvy the file up and try again.
 
         # Unless we've already hit max recursion. In that case, error-out.

--- a/src/ivert/validate_dem.py
+++ b/src/ivert/validate_dem.py
@@ -2434,7 +2434,8 @@ def main(
         sys.exit(1)
 
     # Set up multiprocessing. 'spawn' is the slowest but the most reliable. Otherwise, file handlers are fucking us up.
-    mp.set_start_method("spawn")
+    # force=True avoids a RuntimeError if the start method was already set in this process.
+    mp.set_start_method("spawn", force=True)
 
     # Run the validation
     validate_dem(

--- a/src/ivert/validate_dem.py
+++ b/src/ivert/validate_dem.py
@@ -777,7 +777,7 @@ def validate_dem(
                 output_dir,
                 os.path.splitext(os.path.basename(dem_name))[0] + "_EMPTY.txt",
             )
-            with open(empty_fname, "w") as f:
+            with open(empty_fname, "w", encoding="utf-8") as f:
                 f.write(os.path.basename(dem_name) + " had no IVERT results.")
             shared_ret_values["empty_results_filename"] = empty_fname
 
@@ -1733,7 +1733,7 @@ def _write_validation_outputs(
         if verbose:
             print("No valid results in results dataframe. No outputs computed.")
         if mark_empty_results:
-            with open(empty_results_filename, "w") as f:
+            with open(empty_results_filename, "w", encoding="utf-8") as f:
                 f.write("No ICESat-2 data data overlapping this DEM to validate.")
             if verbose:
                 print(
@@ -1910,7 +1910,7 @@ def validate_dem_parallel(
     )
     if fetch_result is None:
         if mark_empty_results:
-            with open(empty_results_filename, "w") as f:
+            with open(empty_results_filename, "w", encoding="utf-8") as f:
                 f.write(os.path.basename(dem_name) + " had no ICESat-2 results.")
             if verbose:
                 print(
@@ -1938,7 +1938,7 @@ def validate_dem_parallel(
     )
     if overlap_result is None:
         if mark_empty_results:
-            with open(empty_results_filename, "w") as f:
+            with open(empty_results_filename, "w", encoding="utf-8") as f:
                 f.write(os.path.basename(dem_name) + " had no ICESat-2 results.")
             if verbose:
                 print(
@@ -2083,7 +2083,7 @@ def write_summary_stats_file(
     )
 
     out_text = "\n".join(lines)
-    with open(statsfile_name, "w") as outf:
+    with open(statsfile_name, "w", encoding="utf-8") as outf:
         outf.write(out_text)
 
     if verbose:

--- a/src/ivert/validate_dem_collection.py
+++ b/src/ivert/validate_dem_collection.py
@@ -619,7 +619,8 @@ def main(
     # the program to crash when it tries to write files there. That's a user error.
 
     # Set up multiprocessing. 'spawn' is the slowest but the most reliable. Otherwise, file handlers are fucking us up.
-    mp.set_start_method("spawn")
+    # force=True avoids a RuntimeError if the start method was already set in this process.
+    mp.set_start_method("spawn", force=True)
 
     validate_list_of_dems(
         directory_or_files,


### PR DESCRIPTION
## Summary

Fixes a set of cross-platform compatibility issues so IVERT runs on modern Windows and macOS as well as Linux. Each fix preserves existing Linux behavior. No functional change on Linux.

## Fixes

- **Config path resolution (`configfile.py`)** — Path detection was gated on `sys.platform`: the Windows branch only recognized values containing a backslash, but the `.ini` files use forward slashes (e.g. `~/.ivert`). On Windows those values fell through unhandled, leaving `~` unexpanded. Replaced the two platform-specific branches with one platform-agnostic branch (treats a value as a path if it contains `~`, `/`, or `\`) plus an `_is_absolute_path()` helper that recognizes Unix, Windows drive, and UNC roots regardless of OS. On Windows `~/.ivert` now resolves to `C:\Users\<user>\.ivert`.

- **`signal.SIGKILL` guard (`validate_dem.py`)** — `signal.SIGKILL` does not exist on Windows, so `abs(exitcode) == abs(signal.SIGKILL)` raised `AttributeError` whenever a validation subprocess exited non-zero. Look the attribute up with `getattr` and skip the OOM-killer recovery branch when it is absent (Windows has no SIGKILL / OOM-killer); a failed worker now surfaces as the intended `RuntimeError`.

- **Cross-platform terminal colors (`bcolors.py`)** — Raw ANSI escape codes render on Linux/macOS but appear as literal garbage on Windows consoles, where virtual-terminal processing is off by default. Enable it on import via `colorama.just_fix_windows_console()` (no-op elsewhere; only sets the console-mode flag, does not wrap `sys.stdout`, so it does not interfere with `loggerproc.Logger`'s stdout redirection). `colorama` added as a Windows-only dependency; the import is defensive so Linux/macOS degrade to native ANSI.

- **Multiprocessing start method (`validate_dem.py`, `validate_dem_collection.py`)** — `set_start_method("spawn")` raises `RuntimeError` if the start method was already set. Pass `force=True` so re-invocation cannot crash.

- **Explicit UTF-8 encoding** — Text-mode `open()` defaults to the platform locale encoding (e.g. cp1252 on Windows). Pass `encoding="utf-8"` on all text-mode opens (empty-result markers, summary stats, user config, photon-tile lists, the AWS datasource probe, and the process logger). Binary opens are unchanged.

## Testing

Verified on Linux: config paths still resolve to the correct absolute home-directory locations; the SIGKILL decision logic was unit-checked across POSIX/Windows exit-code cases; bcolors imports and renders (VT-enable is a no-op on Linux and degrades gracefully if colorama is absent); `set_start_method(force=True)` is idempotent; and no text-mode `open()` without an encoding remains. `ruff check` and `ruff format` pass on all changed files.

Not covered here (requires real Windows/macOS hardware): the shared-memory + `spawn` parallel-validation path in `validate_dem.py` — Windows frees named `SharedMemory` segments when the last handle closes, unlike Linux `/dev/shm`, so that flow should be exercised directly on the target platform.
