### PR TITLE
Remove unused config keys and orphaned version module

### DIFF
--- a/src/ivert/cli.py
+++ b/src/ivert/cli.py
@@ -84,7 +84,8 @@ def ivert_cli(ctx, user_config, verbosity):
 # options
 ###############################################################
 
-_OPTIONS_EXCLUDED_KEYS = {"ivert_version", "atlas_sdp_epoch", "project_base_directory"}
+# Keys that are read-only and hidden from the "ivert options" command.
+_OPTIONS_EXCLUDED_KEYS: set[str] = set()
 
 
 class _OptionsGroup(click.Group):

--- a/src/ivert/config/ivert_defaults.ini
+++ b/src/ivert/config/ivert_defaults.ini
@@ -4,22 +4,9 @@
 # assigned as absolute paths. To avoid the conversion to absolute paths, wrap the string in quotes (" ") and it'll
 # just be read as-is.
 
-# The base directory of this project. All relative directory paths are relative to the location of THIS FILE.
-# The utils.configfile utility will turn this into an absolute path upon reading it.
-# An exception is if the variable name begins with "s3_". In that case it's an S3 bucket path and will not be
-# converted to an absolute path.
-
-# This value is harded-coded, not editable in user settings.
-project_base_directory = ../
-
-# The version will be dynamically filled in from the VERSION file at runtime. Do not change here.
-# This value is harded-coded, not editable in user settings.
-ivert_version = None
-
-# ICESat-2 ATL points are given in 'seconds since the atlas_spd_epoch', which is Jan 1, 2018 00:00:00 Zulu time.
-# In Python, convert this to a datetime.
-# This value is harded-coded, not editable in user settings.
-atlas_sdp_epoch = 2018-01-01T00:00:00Z
+# All relative directory paths are relative to the location of THIS FILE. The utils.configfile utility will turn
+# them into absolute paths upon reading them. An exception is if the variable name begins with "s3_". In that case
+# it's an S3 bucket path and will not be converted to an absolute path.
 
 # All the following values are defaults only, and can be reset using the "ivert options" command.
 

--- a/src/ivert/utils/configfile.py
+++ b/src/ivert/utils/configfile.py
@@ -4,7 +4,7 @@ import importlib.resources
 import os
 import re
 
-from ivert.utils import is_aws, version
+from ivert.utils import is_aws
 
 ivert_default_configfile = str(
     importlib.resources.files("ivert").joinpath("config", "ivert_defaults.ini"),
@@ -85,10 +85,6 @@ class Config:
             ivert_default_configfile,
         ):
             self._apply_user_config()
-
-        # If 'ivert_version' is present and not already set, set it.
-        if hasattr(self, "ivert_version") and self.ivert_version is None:
-            self.ivert_version = version.__version__
 
         # If we've generated the Config object for the most-commonly-used IVERT Config file, make it globally available.
         if self._configfile == ivert_default_configfile:

--- a/src/ivert/utils/version.py
+++ b/src/ivert/utils/version.py
@@ -1,4 +1,0 @@
-from ivert import __version__
-
-if __name__ == "__main__":
-    print(__version__)


### PR DESCRIPTION
## Summary

Removes three dead config keys and one orphaned module discovered while auditing `ivert_defaults.ini`. None of these were read anywhere in the codebase (excluding test/archived files).

## Changes

- **`ivert_defaults.ini`**: drop `project_base_directory`, `ivert_version`, and `atlas_sdp_epoch`.
  - `project_base_directory` — relative-path resolution uses the config file's own directory, not this value.
  - `ivert_version` — the `--version` flag reads `ivert.__version__` (from the generated `_version.py`), not this key.
  - `atlas_sdp_epoch` — the ICESat-2 epoch is a hardcoded constant (`_ICESAT2_EPOCH`) in `icesat2_database_v2.py`.
- **`cli.py`**: empty `_OPTIONS_EXCLUDED_KEYS` (mechanism retained for future read-only keys).
- **`configfile.py`**: remove the now-dead `ivert_version` self-population block and its unused `version` import.
- **`utils/version.py`**: delete — nothing imported it.

## Verification

- No residual references to the removed keys/module in non-test/archived code.
- `import ivert`, `ivert.__version__`, and `Config()` all work.
- Pre-commit hooks (ruff check/format) pass.