### PR TITLE
Add 'ivert setup' command for data directories and Earthdata credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,19 +48,27 @@ Three dependencies — `fetchez`, `globato`, and `transformez` — are pulled au
 
 ## Quick start
 
-**1. Download ICESat-2 photon data for your area** (bounding box in W/E/S/N order):
+**1. Set up IVERT's data directories and credentials** (run once on a new machine):
+
+```bash
+ivert setup
+```
+
+This creates the local `~/.ivert` data directories and checks your `~/.netrc` for NASA Earthdata Login credentials, offering to save them if they are not already present. Earthdata credentials are required to download ICESat-2 data ([register for a free account](https://urs.earthdata.nasa.gov/)).
+
+**2. Download ICESat-2 photon data for your area** (bounding box in W/E/S/N order):
 
 ```bash
 ivert database download -- -74.0/-73.0/40.5/41.0
 ```
 
-**2. Validate your DEM:**
+**3. Validate your DEM:**
 
 ```bash
 ivert validate mydem.tif
 ```
 
-**3. Check the output directory** for `mydem_results.h5`, a validation plot (`.png`), and error exports (`.tif`, `.gpkg`).
+**4. Check the output directory** for `mydem_results.h5`, a validation plot (`.png`), and error exports (`.tif`, `.gpkg`).
 
 ---
 
@@ -68,6 +76,7 @@ ivert validate mydem.tif
 
 | Command | Description |
 |---------|-------------|
+| [ivert setup](docs/setup.md) | Create data directories and set up NASA Earthdata credentials |
 | [ivert validate](docs/validate.md) | Validate DEMs against ICESat-2 data |
 | [ivert database](docs/database.md) | Download and manage the local photon database |
 | [ivert cache](docs/cache.md) | View and clear the local file cache |

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,45 @@
+# ivert setup — First-time setup
+
+The `ivert setup` command prepares a machine for running IVERT. Run it once after installing.
+
+```bash
+ivert setup
+```
+
+It does two things:
+
+1. **Creates IVERT's local data directories** under `~/.ivert` (the granule cache, the ICESat-2 database directory, and other working directories). Existing directories are left untouched.
+2. **Checks for NASA Earthdata Login credentials** in your `~/.netrc` file and offers to save them if they are not already present.
+
+---
+
+## Data directories
+
+IVERT stores downloaded ICESat-2 photons, cached datum grids, and other working files under `~/.ivert` by default. `ivert setup` creates these directories up front so they exist before the first download or validation. For each directory it reports whether it was `created` or already `exists`.
+
+The directory locations are configurable via [`ivert options`](options.md); `ivert setup` reads the current configuration, so it honors any custom paths you have set.
+
+---
+
+## NASA Earthdata credentials
+
+Downloading ICESat-2 data from NSIDC requires a free [NASA Earthdata Login](https://urs.earthdata.nasa.gov/) account. IVERT (and its underlying tools) read these credentials from a `machine urs.earthdata.nasa.gov` entry in your `~/.netrc` file.
+
+- **If credentials are already present**, `ivert setup` reports:
+
+  ```
+  NASA Earthdata credentials are already set in your .netrc file.
+  ```
+
+- **If they are not present**, `ivert setup` offers to save them. If you answer `yes`, it prompts for your Earthdata username and password (the password is not echoed) and appends a new entry to `~/.netrc`. Existing entries in the file are preserved, and the file's permissions are set to owner-only (`600`).
+
+You can run `ivert setup` again at any time; it will skip the credential prompt once valid credentials are in place.
+
+---
+
+## Example
+
+```bash
+# Prepare a new machine for IVERT
+ivert setup
+```

--- a/src/ivert/cli.py
+++ b/src/ivert/cli.py
@@ -8,6 +8,7 @@ Command-line interface for the ICESat-2 Validation of Elevations Reporting Tool 
 import glob
 import logging
 import os
+from pathlib import Path
 
 # Set NUMEXPR_MAX_THREADS before any import loads NumExpr, to suppress the
 # "safe limit" warning on machines with many cores.
@@ -78,6 +79,166 @@ def ivert_cli(ctx, user_config, verbosity):
     level, fmt = _VERBOSITY_LEVELS[verbosity_key]
     logging.basicConfig(level=level, format=fmt)
     logging.getLogger().setLevel(level)
+
+
+###############################################################
+# setup
+###############################################################
+
+# NASA Earthdata Login host used for authenticating ICESat-2 data downloads.
+_EARTHDATA_MACHINE = "urs.earthdata.nasa.gov"
+
+
+def _netrc_path():
+    """Return the path to the user's .netrc file."""
+    return os.path.join(os.path.expanduser("~"), ".netrc")
+
+
+def _has_earthdata_credentials(netrc_path, machine=_EARTHDATA_MACHINE):
+    """Return True if netrc_path has a login and password for the given machine.
+
+    Parses the .netrc token stream directly rather than using the stdlib netrc
+    module, which raises on files that are group/world-readable and does not
+    tolerate some entries that are otherwise valid for our purposes.
+    """
+    if not os.path.exists(netrc_path):
+        return False
+
+    try:
+        with open(netrc_path, encoding="utf-8") as f:
+            tokens = f.read().split()
+    except OSError:
+        return False
+
+    i = 0
+    while i < len(tokens):
+        if tokens[i] == "machine" and i + 1 < len(tokens) and tokens[i + 1] == machine:
+            login = password = None
+            j = i + 2
+            # Scan this entry until the next machine/default block.
+            while j < len(tokens) and tokens[j] not in ("machine", "default"):
+                if tokens[j] in ("login", "password", "account") and j + 1 < len(
+                    tokens,
+                ):
+                    if tokens[j] == "login":
+                        login = tokens[j + 1]
+                    elif tokens[j] == "password":
+                        password = tokens[j + 1]
+                    j += 2
+                else:
+                    j += 1
+            if login and password:
+                return True
+            i = j
+            continue
+        i += 1
+    return False
+
+
+def _append_earthdata_credentials(
+    netrc_path,
+    username,
+    password,
+    machine=_EARTHDATA_MACHINE,
+):
+    """Append a machine entry for the given credentials to netrc_path.
+
+    Existing content is preserved (the file is opened in append mode). The file
+    permissions are tightened to owner-only, as .netrc requires.
+    """
+    prefix = ""
+    if os.path.exists(netrc_path):
+        with open(netrc_path, encoding="utf-8") as f:
+            existing = f.read()
+        if existing and not existing.endswith("\n"):
+            prefix = "\n"
+
+    entry = f"machine {machine}\n    login {username}\n    password {password}\n"
+    with open(netrc_path, "a", encoding="utf-8") as f:
+        f.write(prefix + entry)
+
+    # .netrc must be readable only by its owner or tools (and netrc parsers) reject it.
+    try:
+        Path(netrc_path).chmod(0o600)
+    except OSError:
+        pass
+
+
+def _setup_earthdata_credentials():
+    """Check for NASA Earthdata credentials in .netrc, offering to save them."""
+    netrc_path = _netrc_path()
+
+    if _has_earthdata_credentials(netrc_path):
+        click.echo("NASA Earthdata credentials are already set in your .netrc file.")
+        return
+
+    click.echo(
+        "No NASA Earthdata credentials were found in your .netrc file.\n"
+        "IVERT needs NASA Earthdata Login credentials to download ICESat-2 data.\n"
+        "Register for a free account at https://urs.earthdata.nasa.gov/ if you "
+        "do not have one.",
+    )
+    if not click.confirm(
+        "Would you like to enter and save your NASA Earthdata username and password now?",
+        default=False,
+    ):
+        click.echo(
+            "Skipped. Run 'ivert setup' again later to save your credentials.",
+        )
+        return
+
+    username = click.prompt("NASA Earthdata username")
+    password = click.prompt("NASA Earthdata password", hide_input=True)
+
+    _append_earthdata_credentials(netrc_path, username, password)
+    click.echo(f"Saved NASA Earthdata credentials to {netrc_path}.")
+
+
+@ivert_cli.command("setup")
+def setup():
+    """Create IVERT's local data directories and check NASA Earthdata credentials.
+
+    Run once on a new machine. Creates the ~/.ivert data directories and verifies
+    that NASA Earthdata Login credentials are stored in your ~/.netrc file, offering
+    to save them if they are not.
+    """
+    from ivert.utils.configfile import Config
+
+    config = Config()
+
+    # Directory settings, plus the parent directories of key file settings.
+    dir_attrs = (
+        "user_data_directory",
+        "cache_directory",
+        "icesat2_granules_directory",
+        "icesat2_download_directory",
+    )
+    file_attrs = (
+        "user_configfile",
+        "icesat2_granules_gpkg",
+        "icesat2_granules_blosc",
+        "icesat2_requests_csv",
+    )
+    dirs = [getattr(config, attr) for attr in dir_attrs]
+    dirs += [os.path.dirname(getattr(config, attr)) for attr in file_attrs]
+
+    # Dedupe while preserving order.
+    unique_dirs = []
+    seen = set()
+    for d in dirs:
+        if d and d not in seen:
+            seen.add(d)
+            unique_dirs.append(d)
+
+    click.echo("Setting up IVERT data directories...")
+    for d in unique_dirs:
+        existed = os.path.isdir(d)
+        os.makedirs(d, exist_ok=True)
+        status = "exists" if existed else "created"
+        click.echo(f"  [{status}] {d}")
+
+    click.echo()
+    _setup_earthdata_credentials()
 
 
 ###############################################################


### PR DESCRIPTION
## Summary

Adds an `ivert setup` command intended to be run once on a new machine.

**1. Creates the local data directories.** Reads the directory paths from the config (staying in sync with `ivert_defaults.ini`) and creates them with `exist_ok=True`, reporting `[created]` or `[exists]` for each: `~/.ivert`, `~/.ivert/cache`, `~/.ivert/icesat2/granules`, and `~/.ivert/icesat2`.

**2. Checks `~/.netrc` for NASA Earthdata credentials.**
- If a `machine urs.earthdata.nasa.gov` entry with a login and password exists, prints "NASA Earthdata credentials are already set in your .netrc file."
- Otherwise, offers to prompt for a username and password (password hidden) and **appends** them to `~/.netrc` without disturbing existing entries, setting the file to `0600` permissions.

## Notes

- The `.netrc` check parses the token stream directly rather than using the stdlib `netrc` module, which raises on group/world-readable files.
- Append mode preserves unrelated existing entries; a missing trailing newline in the existing file is handled so the new block starts on its own line.

## Testing

Exercised in a throwaway `HOME`: directory creation, decline path, save path (verified `0600` perms and file contents), the "already set" path on re-run, and append-preserving-existing-entries. `prek` (ruff check + ruff format) passes.