### PR TITLE
Keep ivert_results_subdir relative in config attribute and options list

### DIFF
--- a/src/ivert/utils/configfile.py
+++ b/src/ivert/utils/configfile.py
@@ -12,6 +12,13 @@ ivert_default_configfile = str(
 
 ivert_config = None
 
+# Keys whose values are intentionally kept as relative paths rather than being
+# resolved to an absolute path against the configfile's location. These are
+# resolved later against a different base directory (e.g. the DEM being
+# validated), so both the attribute and "ivert options list" must show the
+# original relative string.
+_RELATIVE_PATH_KEYS = frozenset({"ivert_results_subdir"})
+
 
 def _is_absolute_path(value):
     """Return True if 'value' is an absolute filesystem path on any platform.
@@ -184,7 +191,12 @@ class Config:
         # If this is the case, return the absolute path of that file/directory *relative* to the current directory the
         # Config.ini file is contained.
         try:
-            if key[:3].lower() == "s3_":
+            if key.lower() in _RELATIVE_PATH_KEYS:
+                # This path is resolved later against a different base directory
+                # (not the configfile's location), so keep it relative as-is.
+                pass
+
+            elif key[:3].lower() == "s3_":
                 # This is an S3 key-path. Do not convert it to an absolute path.
                 pass
 


### PR DESCRIPTION
## Summary

The `ivert_results_subdir` path is resolved at validation time against each DEM's own directory. However, config parsing was resolving it to an absolute path relative to the ini file's location, so `ivert options list` displayed a misleading absolute path (e.g. `.../site-packages/ivert/config/ivert_results`) instead of the intended relative `ivert_results/`.

## Changes

- Add a `_RELATIVE_PATH_KEYS` set in `configfile.py` for keys that should stay relative.
- In `_read_option()`, skip absolute-path resolution for these keys (same pattern already used for `s3_` and URL values), so both the `Config` attribute and the `options list` output show the original relative string.

## Effect

- `Config().ivert_results_subdir` → `ivert_results/` (previously an absolute path — a latent trap, since only the raw config read was being used).
- `ivert options list` → shows `ivert_results/`.
- Validation still resolves the value against each DEM's directory; the raw config read in `cli.py` is unchanged.
- The `ivert_defaults.ini` value itself is untouched.