### PR TITLE
Add descriptions to 'ivert options' commands

### DIFF
--- a/src/ivert/cli.py
+++ b/src/ivert/cli.py
@@ -258,12 +258,18 @@ class _OptionsGroup(click.Group):
 
     def parse_args(self, ctx, args):
         if args and not args[0].startswith("-") and "=" in args[0]:
+            # Flag this as a bare key=value assignment (not a subcommand) so
+            # invoke() routes it to the group callback rather than a subcommand.
+            ctx.meta["options_passthrough"] = True
             ctx.args = list(args)
             return []
         return super().parse_args(ctx, args)
 
     def invoke(self, ctx):
-        if ctx.args:
+        # Only a key=value passthrough runs the group callback directly. A real
+        # subcommand (e.g. "info <name>") also populates ctx.args with its
+        # positional arguments, so those must route through normal dispatch.
+        if ctx.meta.get("options_passthrough"):
             click.Command.invoke(self, ctx)
             return
         super().invoke(ctx)
@@ -326,9 +332,16 @@ def _options_set_values(assignments):
 
 
 @options.command("list")
-def options_list():
+@click.option(
+    "-d",
+    "--details",
+    is_flag=True,
+    default=False,
+    help="Show a description of what each setting means.",
+)
+def options_list(details):
     """List all configurable settings and their current values."""
-    from ivert.utils.configfile import Config
+    from ivert.utils.configfile import Config, parse_option_descriptions
 
     config = Config()
     keys = [
@@ -339,26 +352,92 @@ def options_list():
         click.echo("No configurable settings found.")
         return
 
-    col_w = max(len(k) for k in keys)
-    header = click.style(f"{'Setting':<{col_w}}", bold=True)
-    click.echo(f"\n  {header}  Value")
-    click.echo("  " + "-" * (col_w + 2 + 56))
+    descriptions = parse_option_descriptions() if details else {}
 
-    for key in keys:
-        value = str(getattr(config, key, ""))
-        is_user = key in config._user_set_keys
-        colored_key = click.style(f"{key:<{col_w}}", fg="cyan")
-        source = (
-            click.style("[user]", fg="yellow")
-            if is_user
-            else click.style("[default]", fg="bright_black")
-        )
-        click.echo(f"  {colored_key}  {value:<52}  {source}")
+    if details:
+        click.echo("")
+        for key in keys:
+            value = str(getattr(config, key, ""))
+            is_user = key in config._user_set_keys
+            source = (
+                click.style("[user]", fg="yellow")
+                if is_user
+                else click.style("[default]", fg="bright_black")
+            )
+            click.echo(
+                f"  {click.style(key, fg='cyan', bold=True)}  = {value}  {source}",
+            )
+            desc = descriptions.get(key)
+            if desc:
+                for line in desc.splitlines():
+                    click.echo(f"      {line}")
+            else:
+                click.echo(
+                    click.style("      (no description available)", fg="bright_black"),
+                )
+            click.echo("")
+    else:
+        col_w = max(len(k) for k in keys)
+        header = click.style(f"{'Setting':<{col_w}}", bold=True)
+        click.echo(f"\n  {header}  Value")
+        click.echo("  " + "-" * (col_w + 2 + 56))
+
+        for key in keys:
+            value = str(getattr(config, key, ""))
+            is_user = key in config._user_set_keys
+            colored_key = click.style(f"{key:<{col_w}}", fg="cyan")
+            source = (
+                click.style("[user]", fg="yellow")
+                if is_user
+                else click.style("[default]", fg="bright_black")
+            )
+            click.echo(f"  {colored_key}  {value:<52}  {source}")
 
     click.echo(
         "\n  To change a setting:  ivert options option_name=new_value"
-        "\n  Add quotes around values containing spaces or special characters.",
+        "\n  Add quotes around values containing spaces or special characters."
+        "\n  For a description of each setting:  ivert options list --details"
+        "\n  For one setting:  ivert options info <option_name>",
     )
+
+
+@options.command("info")
+@click.argument("option_name")
+def options_info(option_name):
+    """Show a description of a single setting, its current value, and default."""
+    from ivert.utils.configfile import Config, parse_option_descriptions
+
+    config = Config()
+    key = option_name.strip().lower()
+
+    if key in _OPTIONS_EXCLUDED_KEYS or key not in config._config["DEFAULT"]:
+        raise click.UsageError(
+            f"Unknown setting '{option_name}'. "
+            "Run 'ivert options list' to see valid settings.",
+        )
+
+    value = str(getattr(config, key, ""))
+    default_value = config._config["DEFAULT"].get(key, "")
+    is_user = key in config._user_set_keys
+    descriptions = parse_option_descriptions()
+
+    click.echo("")
+    click.echo(f"  {click.style(key, fg='cyan', bold=True)}")
+    desc = descriptions.get(key)
+    if desc:
+        for line in desc.splitlines():
+            click.echo(f"      {line}")
+    else:
+        click.echo(
+            click.style("      (no description available)", fg="bright_black"),
+        )
+
+    click.echo("")
+    source = "user-set" if is_user else "default"
+    click.echo(f"  Current value: {value}  ({source})")
+    if is_user:
+        click.echo(f"  IVERT default: {default_value}")
+    click.echo(f"\n  To change it:  ivert options {key}=<new_value>")
 
 
 @options.command("reset")

--- a/src/ivert/config/ivert_defaults.ini
+++ b/src/ivert/config/ivert_defaults.ini
@@ -1,57 +1,105 @@
 [DEFAULT]
-# In the code from configparser.Config(), paths will be automatically detected by looking for a folder delimiter
-# ("/" on linux/cygwin, "\" on Windows). If the paths are absolute (starting with the root drive), they will be
-# assigned as absolute paths. To avoid the conversion to absolute paths, wrap the string in quotes (" ") and it'll
-# just be read as-is.
+# In the code from configparser.Config(), paths will be automatically
+# detected by looking for a folder delimiter ("/" on linux/cygwin, "\"
+# on Windows). If the paths are absolute (starting with the root drive),
+# they will be assigned as absolute paths. To avoid the conversion to
+# absolute paths, wrap the string in quotes (" ") and it'll be read as-is.
 
-# All relative directory paths are relative to the location of THIS FILE. The utils.configfile utility will turn
-# them into absolute paths upon reading them. An exception is if the variable name begins with "s3_". In that case
-# it's an S3 bucket path and will not be converted to an absolute path.
+# All relative directory paths are relative to the location of THIS FILE.
+# The utils.configfile utility will turn them into absolute paths upon
+# reading them. An exception is if the variable name begins with "s3_".
+# In that case it's an S3 bucket path and will not be converted to an
+# absolute path. Another specific exception is "ivert_results_subdir",
+# which remains a sub-directory of the DEM being validated, and does not
+# resolve to a directory relative to this configuration file.
 
-# All the following values are defaults only, and can be reset using the "ivert options" command.
+# All the following values are defaults only, and can be reset using the
+# "ivert options" command.
 
+# Default nodata value assumed for input DEMs that do not declare one of
+# their own. Pixels equal to this value are excluded from validation.
+# "NaN" treats not-a-number cells as nodata; a numeric value (e.g. -9999)
+# treats that value as nodata instead.
 dem_default_ndv = NaN
 
+# NSIDC ATL product version to request when downloading ICESat-2 granules,
+# as a zero-padded string (e.g. "006", "007"). Change this when NSIDC
+# releases a newer ATL data version that you want IVERT to use.
 nsidc_atl_version = "007"
 
+# Root directory for all of IVERT's local data (cache, ICESat-2 granules,
+# database, and the user config file). Most other paths below are defined
+# relative to this one, so changing it relocates the whole IVERT data
+# tree.
 user_data_directory = ~/.ivert
+
+# Location of your personal config file, where "ivert options" writes any
+# settings you change. Values here override these defaults. By default it
+# lives inside user_data_directory.
 user_configfile = %(user_data_directory)s/user_config.ini
 
-# Where to store icesat2, OpenStreetMap, and other data needed when building the database and/or processing granules.
+# Where to store icesat2, OpenStreetMap, and other data needed when
+# building the database and/or processing granules.
 cache_directory = %(user_data_directory)s/cache
 
+# Directory where downloaded ICESat-2 ATL granules (HDF5 files) are stored
+# after retrieval.
 icesat2_granules_directory = %(user_data_directory)s/icesat2/granules
-# By default, raw icesat2 granule downloads go in the same place as the cache directory for other data. It can be
-# separated here if you want.
+
+# By default, raw icesat2 granule downloads go in the same place as the
+# cache directory for other data. Separate it here if you want to download
+# ICESat-2 granules specifically to another local directory.
 icesat2_download_directory = %(cache_directory)s
+
+# GeoPackage holding the spatial index of ICESat-2 granules (their
+# footprints and metadata), used to look up which granules cover a
+# given DEM.
 icesat2_granules_gpkg = %(user_data_directory)s/icesat2/icesat2_granules_database.gpkg
+
+# Blosc-compressed binary copy of the granules database, used as a
+# faster-loading cache of the same information stored in
+# icesat2_granules_gpkg.
 icesat2_granules_blosc = %(user_data_directory)s/icesat2/icesat2_granules_database.blosc
+
 # The CSV file to use to keep track of previous icesat2 requests.
 icesat2_requests_csv = %(user_data_directory)s/icesat2/requests.csv
-# The last date (YYYYMMDD) for which ATL24 bathymetry classifications are available.
-# ATL24 data is only reprocessed periodically. Update this via "ivert options atl24_date_cutoff=YYYYMMDD"
-# when a new version of ATL24 data becomes available.
+
+# The last date (YYYYMMDD) for which ATL24 bathymetry classifications are
+# available. ATL24 data is only reprocessed periodically. Update this via
+# "ivert options atl24_date_cutoff=YYYYMMDD" when a new version of ATL24
+# data becomes available.
 atl24_date_cutoff = 20241107
-# IVERT vertical datum. Save the photons in the database in EGM2008 geoid, or WGS84 ellipsoid heights.
-# The two choices for this variable are "geoid" or "ellipsoid".
-# All photons will be converted into the DEM's vertical datum upon validation.
+
+# IVERT vertical datum. Save the photons in the database in EGM2008 geoid,
+# or WGS84 ellipsoid heights. The two choices for this variable are
+# "geoid" or "ellipsoid". All photons will be converted into the DEM's
+# vertical datum upon validation. Saving as "ellipsoid" simplifies
+# conversions to other vertical datums. Saving as "geoid" saves photons
+# natively to a datum that approximates gravitational mean sea level.
 # "ellipsoid" : WGS84 Ellipsoid heights (EPSG: 4979)
 # "geoid"     : EGM 2008 Geoid heights (EPSG: 3855)
 icesat2_vertical_datum="ellipsoid"
 
-# ivert_results_subdir is a relative directory, where (by default) ivert results are written when dems are validated.
-# This is a directory relative to the path of the DEMs being validated, not the current working directory of the process.
+# Relative directory where (by default) ivert results are written when
+# DEMs are validated. This is relative to the path of the DEMs being
+# validated, not the current working directory of the process.
 ivert_results_subdir = ivert_results/
 
-# verbosity level. Sets "logging.info" to the following levels of verbosity.
-# Choices are:
-# "debug": See detailed output from all code and libraries. Extremely verbose, probably annoying for general execution
-#             but good for debugging.
-# "info": See steps happening as they occur in the code.
-# "warning": Omit info statements, but print warning statements to the screen (to stderr). This is "quiet" mode.
-# "error": Only print breaking errors to stderr. This is "very-quiet" mode.
+# Verbosity level. Sets "logging.info" to the following levels of
+# verbosity. Choices are:
+# "debug":   See detailed output from all code and libraries. Extremely
+#            verbose, probably annoying for general execution but good
+#            for debugging.
+# "info":    See steps happening as they occur in the code. (Default.)
+# "warning": Omit info statements, but print warning statements to the
+#            screen (to stderr). This is "quiet" mode.
+# "error":   Only print breaking errors to stderr. This is "silent" mode.
+# NOTE: Not all print() statements have yet been converted to
+# logging.info statements in ivert. Upcoming releases will fix this.
 verbosity = info
 
-# Comma separated list of formats in which the output_errors should be exported (derived from the _results.h5 file
-# for each DEM validated). Values include "tif", "gpkg", "shp", and "xyz".
+# A comma-separated list of formats in which the output_errors should be
+# exported (derived from the _results.h5 file for each DEM validated).
+# Values include "tif" (GeoTiff), "gpkg" (GeoPackage), "shp" (ESRI
+# Shapefile), and "xyz" (XYZ text file).
 export_error_formats= tif,gpkg

--- a/src/ivert/utils/configfile.py
+++ b/src/ivert/utils/configfile.py
@@ -20,6 +20,56 @@ ivert_config = None
 _RELATIVE_PATH_KEYS = frozenset({"ivert_results_subdir"})
 
 
+def parse_option_descriptions(configfile: str = ivert_default_configfile):
+    """Extract the descriptive comments for each option in a config .ini file.
+
+    configparser discards comments, so the human-readable descriptions written
+    above each setting in ivert_defaults.ini are parsed here directly from the
+    file text. A description is the block of contiguous "#" comment lines that
+    immediately precedes a "key = value" assignment (with no blank line in
+    between). Header/section comments separated from any key by a blank line are
+    not attached to a setting.
+
+    Returns a dict mapping lower-cased option name -> description string (the
+    comment block with leading "# " markers stripped, newlines preserved).
+    Options with no preceding comment are omitted.
+    """
+    descriptions = {}
+    comment_buffer = []
+
+    with open(configfile, encoding="utf-8") as f:
+        for raw_line in f:
+            line = raw_line.strip()
+
+            if not line:
+                # Blank line ends a comment block so headers don't leak onto keys.
+                comment_buffer = []
+                continue
+
+            if line.startswith("#"):
+                # Drop the leading "#" marker(s) and a single following space,
+                # but keep any further indentation so aligned multi-line
+                # descriptions (e.g. the verbosity option list) stay aligned.
+                content = line.lstrip("#")
+                content = content.removeprefix(" ")
+                comment_buffer.append(content.rstrip())
+                continue
+
+            if line.startswith("[") and line.endswith("]"):
+                # Section header (e.g. [DEFAULT], [AWS]).
+                comment_buffer = []
+                continue
+
+            # An assignment line: attach any accumulated comment block to the key.
+            if "=" in line:
+                key = line.split("=", 1)[0].strip().lower()
+                if key and comment_buffer:
+                    descriptions[key] = "\n".join(comment_buffer)
+            comment_buffer = []
+
+    return descriptions
+
+
 def _is_absolute_path(value):
     """Return True if 'value' is an absolute filesystem path on any platform.
 


### PR DESCRIPTION
## Summary

Gives users a way to read what each configurable setting actually means, without leaving the CLI. Descriptions are sourced from the comments already written above each option in `ivert_defaults.ini` — `configparser` discards comments, so they are parsed directly from the file text.

## Changes

- **New `parse_option_descriptions()`** in `configfile.py`: associates each contiguous `#` comment block with the option directly beneath it (blank lines separate blocks, so file/section headers don't leak onto keys). Intentional indentation in multi-line descriptions is preserved.
- **`ivert options info <name>`**: shows one setting's description, current value, source (`user`/`default`), the IVERT default, and how to change it.
- **`ivert options list --details`** (`-d`): lists every setting with its description; the plain `list` footer now advertises both new views.
- **Bug fix in `_OptionsGroup`**: subcommands taking positional arguments (like `info <name>`) were being misrouted to the `key=value` setter. The bare-assignment case is now flagged explicitly during `parse_args`, which also avoids Click's deprecated `protected_args`.
- **Documented every option** in `ivert_defaults.ini` (7 previously had no comment) and rewrapped all comments so descriptions fit within an 80-column terminal without wrapping.

## Testing

- All 15 options parse and render correctly through both `info` and `list --details`.
- Widest displayed description line is 78 columns.
- `key=value` passthrough, `options list`, and `options info <bad-key>` error paths all verified.