### PR TITLE
Add coverage summary stats and --minimum-coverage-pct filter to validate

### DIFF
--- a/src/ivert/cli.py
+++ b/src/ivert/cli.py
@@ -1104,6 +1104,7 @@ def _run_validate(
     export_formats=None,
     overwrite=False,
     exclude_zones=None,
+    minimum_coverage_pct=None,
 ):
     """Branch to validate_dem or validate_list_of_dems based on the number of input files."""
     verbose = logging.getLogger().level <= logging.INFO
@@ -1184,6 +1185,7 @@ def _run_validate(
             include_photon_level_validation=include_photons,
             location_name=region_name,
             measure_coverage=measure_coverage,
+            min_coverage_pct=minimum_coverage_pct,
             min_confidence_level=confidence_level,
             min_bathy_confidence=bathy_confidence,
             verbose=verbose,
@@ -1218,6 +1220,7 @@ def _run_validate(
             place_name=region_name,
             include_photon_validation=include_photons,
             measure_coverage=measure_coverage,
+            min_coverage_pct=minimum_coverage_pct,
             outliers_sd_threshold=outlier_sd_threshold,
             min_confidence_level=confidence_level,
             min_bathy_confidence=bathy_confidence,
@@ -1291,6 +1294,18 @@ def _run_validate(
         "Measure relative photon coverage per grid cell (fraction of 15x15 "
         "sub-regions containing photons). Useful for post-processing "
         "coarse-resolution DEMs where sampling bias may matter."
+    ),
+)
+@click.option(
+    "-mcp",
+    "--minimum-coverage-pct",
+    "minimum_coverage_pct",
+    type=click.FloatRange(0, 100),
+    default=None,
+    help=(
+        "Only validate grid cells whose measured coverage is at or above this "
+        "percentage (0-100); lower-coverage cells are dropped from the results, "
+        "statistics, and plots. Requires the -mc/--measure-coverage flag."
     ),
 )
 @click.option(
@@ -1414,6 +1429,7 @@ def validate(
     region_name,
     include_photons,
     measure_coverage,
+    minimum_coverage_pct,
     band_num,
     outlier_sd_threshold,
     buildings,
@@ -1453,6 +1469,12 @@ def validate(
     if not files_or_directory:
         raise click.UsageError("Missing argument 'FILES_OR_DIRECTORY'.")
 
+    if minimum_coverage_pct is not None and not measure_coverage:
+        raise click.UsageError(
+            "--minimum-coverage-pct requires the -mc/--measure-coverage flag "
+            "(coverage must be measured before it can be filtered on).",
+        )
+
     exclude_zones = (
         [_parse_exclude_spec(value) for value in exclude] if exclude else None
     )
@@ -1473,6 +1495,7 @@ def validate(
         export_formats=export_formats,
         overwrite=overwrite,
         exclude_zones=exclude_zones,
+        minimum_coverage_pct=minimum_coverage_pct,
     )
 
 

--- a/src/ivert/validate_dem.py
+++ b/src/ivert/validate_dem.py
@@ -486,6 +486,7 @@ def validate_dem(
     location_name: str | None = None,
     mark_empty_results: bool = True,
     measure_coverage: bool = False,
+    min_coverage_pct: float | None = None,
     max_photons_per_cell: int | None = None,
     numprocs: int = parallel_funcs.physical_cpu_count(),
     max_subdivides: int = 4,
@@ -527,6 +528,10 @@ def validate_dem(
         location_name (str): Name of the location being validated.
         mark_empty_results (bool): Mark results that are empty in an "_EMPTY.txt" file.
         measure_coverage (bool): Measure the coverage of ICESat-2 photons within each grid-cell.
+        min_coverage_pct (float): If set, drop grid cells whose measured coverage is below this
+            percentage (0-100) from the validation results, stats, and plots. Requires
+            measure_coverage=True (coverage must be measured to filter on it). Defaults to None
+            (no coverage filtering).
         max_photons_per_cell (int): Maximum number of photons per cell.
         numprocs (int): Number of processes to use for parallelized validation.
         max_subdivides (int): Maximum number of times to subdivide the DEM in quarters before giving up.
@@ -570,6 +575,7 @@ def validate_dem(
         "location_name": location_name,
         "mark_empty_results": mark_empty_results,
         "measure_coverage": measure_coverage,
+        "min_coverage_pct": min_coverage_pct,
         "max_photons_per_cell": max_photons_per_cell,
         "numprocs": numprocs,
         "min_confidence_level": min_confidence_level,
@@ -666,6 +672,7 @@ def validate_dem(
                 location_name=location_name,
                 mark_empty_results=mark_empty_results,
                 measure_coverage=measure_coverage,
+                min_coverage_pct=min_coverage_pct,
                 max_photons_per_cell=max_photons_per_cell,
                 numprocs=numprocs,
                 min_confidence_level=min_confidence_level,
@@ -1657,6 +1664,7 @@ def _write_validation_outputs(
     verbose,
     files_to_export,
     export_error_formats=None,
+    min_coverage_pct=None,
 ):
     """Concatenate results, filter outliers, and write all output files.
 
@@ -1671,6 +1679,20 @@ def _write_validation_outputs(
         & (~numpy.isnan(results_dataframe["mean"]))
         & (results_dataframe["numphotons_intd"] >= 3)
     ].copy()
+
+    # Drop cells below the requested minimum ICESat-2 coverage. Coverage is a
+    # per-cell property, so filtering here (per subset, before any outlier removal)
+    # gives the same result as filtering the merged dataframe.
+    if min_coverage_pct is not None and "coverage_frac" in results_dataframe.columns:
+        n_before = len(results_dataframe)
+        results_dataframe = results_dataframe[
+            results_dataframe["coverage_frac"] >= (min_coverage_pct / 100.0)
+        ].copy()
+        if verbose:
+            print(
+                f"{len(results_dataframe):,} of {n_before:,} DEM cells remain after applying the "
+                f"{min_coverage_pct:g}% minimum-coverage filter.",
+            )
 
     if verbose:
         print(
@@ -1788,6 +1810,7 @@ def validate_dem_parallel(
     mark_empty_results: bool = True,
     omit_bboxes: None | list[float] | tuple[float] = None,
     measure_coverage: bool = False,
+    min_coverage_pct: float | None = None,
     max_photons_per_cell: int | None = None,
     numprocs: int = parallel_funcs.physical_cpu_count(),
     min_confidence_level: int = 4,
@@ -1953,7 +1976,31 @@ def validate_dem_parallel(
         verbose,
         files_to_export,
         export_error_formats=export_error_formats,
+        min_coverage_pct=min_coverage_pct,
     )
+
+
+def _format_stat(value) -> str:
+    """Format a float for the summary stats file with reasonable precision.
+
+    Uses 2 decimal places, unless the magnitude is below 0.10 (but non-zero), in
+    which case it uses enough decimal places to show at least 2 significant digits.
+
+    Args:
+        value: the number to format.
+
+    Returns:
+        A string representation of the number.
+
+    """
+    x = float(value)
+    if not numpy.isfinite(x):
+        return str(x)
+    if x != 0 and abs(x) < 0.10:
+        # Enough decimals to show 2 significant digits for small magnitudes.
+        decimals = 1 - int(numpy.floor(numpy.log10(abs(x))))
+        return f"{x:.{decimals}f}"
+    return f"{x:.2f}"
 
 
 def write_summary_stats_file(
@@ -1994,15 +2041,17 @@ def write_summary_stats_file(
     )
     lines.append(
         "Mean number of photons used to validate each cell (photons): {0}".format(
-            results_df["numphotons_intd"].mean(),
+            _format_stat(results_df["numphotons_intd"].mean()),
         ),
     )
 
     mean_diff = results_df["diff_mean"]
 
-    lines.append(f"Mean bias error (DEM - ICESat-2) (m): {mean_diff.mean()}")
     lines.append(
-        f"RMSE (m): {numpy.sqrt(numpy.mean(numpy.power(mean_diff, 2)))}",
+        f"Mean bias error (DEM - ICESat-2) (m): {_format_stat(mean_diff.mean())}",
+    )
+    lines.append(
+        f"RMSE (m): {_format_stat(numpy.sqrt(numpy.mean(numpy.power(mean_diff, 2))))}",
     )
     lines.append(
         "== Decile ranges of errors (DEM - ICESat-2) (m) (Look for long-tails, indicating possible artifacts.) ===",
@@ -2011,7 +2060,7 @@ def write_summary_stats_file(
     percentile_levels = [0, 1, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95, 99, 100]
     percentile_values = numpy.percentile(mean_diff, percentile_levels)
     for level, v in zip(percentile_levels, percentile_values):
-        lines.append(f"    {level:>3d} percentile error level (m): {v}")
+        lines.append(f"    {level:>3d} percentile error level (m): {_format_stat(v)}")
 
     lines.append(
         "Number of cells with bathymetry photons: {0:d}".format(
@@ -2024,9 +2073,29 @@ def write_summary_stats_file(
     # lines.append("Mean canopy cover in 'wooded' cells containing >0 canopy (% cover): {0}".format(results_df[results_df["canopy_fraction"] > 0]["canopy_fraction"].mean()*100))
     lines.append(
         "Mean roughness (stddev. of photon elevations within each cell (m)): {0}".format(
-            results_df["stddev"].mean(),
+            _format_stat(results_df["stddev"].mean()),
         ),
     )
+
+    if "coverage_frac" in results_df.columns:
+        # Rank cells by ICESat-2 coverage and report the RMSE of the best-covered
+        # subsets. This shows how coverage (and thus sampling bias) affects the
+        # reported DEM accuracy: each line keeps only the cells whose coverage is at
+        # or above a decile threshold, from all cells (100%) to the best-covered 10%.
+        coverage_frac = results_df["coverage_frac"]
+        lines.append(
+            "== RMSE by ICESat-2 coverage decile "
+            "(how coverage/sampling bias affects reported accuracy) ===",
+        )
+        for pct_of_cells in range(100, 0, -10):
+            # The coverage threshold that retains this fraction of the best-covered cells.
+            coverage_threshold = numpy.percentile(coverage_frac, 100 - pct_of_cells)
+            mask = coverage_frac >= coverage_threshold
+            subset_diff = mean_diff[mask]
+            rmse = numpy.sqrt(numpy.mean(numpy.power(subset_diff, 2)))
+            lines.append(
+                f"    RMSE for grid cells with >{coverage_threshold * 100:0.1f}% coverage ({pct_of_cells:d}% of cells) (m): {_format_stat(rmse)}",
+            )
 
     out_text = "\n".join(lines)
     with open(statsfile_name, "w", encoding="utf-8") as outf:
@@ -2313,6 +2382,14 @@ def export_error_results(
     help="Measure the coverage %age of icesat-2 data in each of the output DEM cells.",
 )
 @click.option(
+    "--minimum_coverage_pct",
+    "-mcp",
+    type=float,
+    default=None,
+    help="Only validate DEM grid cells whose measured coverage is at or above this "
+    "percentage (0-100). Requires the -mc/--measure_coverage flag.",
+)
+@click.option(
     "--outlier_sd_threshold",
     default="2.5",
     help="Number of standard-deviations away from the mean to omit outliers. Default 2.5 (standard deviations). Choose 'None' if no outlier filtering is requested.",
@@ -2346,6 +2423,7 @@ def main(
     numprocs,
     delete_datafiles,
     measure_coverage,
+    minimum_coverage_pct,
     outlier_sd_threshold,
     plot_results,
     overwrite,
@@ -2356,6 +2434,12 @@ def main(
     INPUT_DEM is the input DEM. OUTPUT_DIR is the directory to write output
     results; defaults to the same directory as the input filename.
     """
+    if minimum_coverage_pct is not None and not measure_coverage:
+        raise click.UsageError(
+            "--minimum_coverage_pct requires the -mc/--measure_coverage flag "
+            "(coverage must be measured before it can be filtered on).",
+        )
+
     # The output directory defaults to the input directory.
     if not output_dir:
         output_dir = os.path.dirname(input_dem)
@@ -2389,6 +2473,7 @@ def main(
         location_name=place_name,
         outliers_sd_threshold=ast.literal_eval(outlier_sd_threshold),
         measure_coverage=measure_coverage,
+        min_coverage_pct=minimum_coverage_pct,
         numprocs=numprocs,
         band_num=band_num,
         verbose=not quiet,

--- a/src/ivert/validate_dem.py
+++ b/src/ivert/validate_dem.py
@@ -2053,14 +2053,6 @@ def write_summary_stats_file(
     lines.append(
         f"RMSE (m): {_format_stat(numpy.sqrt(numpy.mean(numpy.power(mean_diff, 2))))}",
     )
-    lines.append(
-        "== Decile ranges of errors (DEM - ICESat-2) (m) (Look for long-tails, indicating possible artifacts.) ===",
-    )
-
-    percentile_levels = [0, 1, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95, 99, 100]
-    percentile_values = numpy.percentile(mean_diff, percentile_levels)
-    for level, v in zip(percentile_levels, percentile_values):
-        lines.append(f"    {level:>3d} percentile error level (m): {_format_stat(v)}")
 
     lines.append(
         "Number of cells with bathymetry photons: {0:d}".format(
@@ -2076,6 +2068,15 @@ def write_summary_stats_file(
             _format_stat(results_df["stddev"].mean()),
         ),
     )
+
+    lines.append(
+        "== Decile ranges of errors (DEM - ICESat-2) (m) (Look for long-tails, indicating possible artifacts.) ===",
+    )
+
+    percentile_levels = [0, 1, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95, 99, 100]
+    percentile_values = numpy.percentile(mean_diff, percentile_levels)
+    for level, v in zip(percentile_levels, percentile_values):
+        lines.append(f"    {level:>3d} percentile error level (m): {_format_stat(v)}")
 
     if "coverage_frac" in results_df.columns:
         # Rank cells by ICESat-2 coverage and report the RMSE of the best-covered

--- a/src/ivert/validate_dem_collection.py
+++ b/src/ivert/validate_dem_collection.py
@@ -104,6 +104,7 @@ def validate_list_of_dems(
     include_photon_validation: bool = True,
     write_summary_csv: bool = True,
     measure_coverage: bool = False,
+    min_coverage_pct: float | None = None,
     outliers_sd_threshold: float = 2.5,
     min_confidence_level: int = 1,
     min_bathy_confidence: float = 0.75,
@@ -342,6 +343,7 @@ def validate_list_of_dems(
                 outliers_sd_threshold=outliers_sd_threshold,
                 mark_empty_results=True,
                 measure_coverage=measure_coverage,
+                min_coverage_pct=min_coverage_pct,
                 min_confidence_level=min_confidence_level,
                 min_bathy_confidence=min_bathy_confidence,
                 export_error_formats=export_error_formats,
@@ -546,6 +548,14 @@ def validate_list_of_dems(
     help="Measure the coverage %age of icesat-2 data in each of the output DEM cells.",
 )
 @click.option(
+    "--minimum_coverage_pct",
+    "-mcp",
+    type=float,
+    default=None,
+    help="Only validate DEM grid cells whose measured coverage is at or above this "
+    "percentage (0-100). Requires the -mc/--measure_coverage flag.",
+)
+@click.option(
     "-wsc",
     "--write_summary_csv",
     type=yes_no.interpret_yes_no,
@@ -567,6 +577,7 @@ def main(
     delete_datafiles,
     outlier_sd_threshold,
     measure_coverage,
+    minimum_coverage_pct,
     write_summary_csv,
     quiet,
 ):
@@ -574,6 +585,12 @@ def main(
 
     DIRECTORY_OR_FILES is a directory path, or a list of individual DEM tiles.
     """
+    if minimum_coverage_pct is not None and not measure_coverage:
+        raise click.UsageError(
+            "--minimum_coverage_pct requires the -mc/--measure_coverage flag "
+            "(coverage must be measured before it can be filtered on).",
+        )
+
     directory_or_files = list(directory_or_files)
 
     if output_dir is None:
@@ -628,6 +645,7 @@ def main(
         # mask_out_lakes=mask_lakes,
         # omit_bad_granules=True,
         measure_coverage=measure_coverage,
+        min_coverage_pct=minimum_coverage_pct,
         write_summary_csv=write_summary_csv,
         outliers_sd_threshold=ast.literal_eval(outlier_sd_threshold),
         verbose=not quiet,


### PR DESCRIPTION
## Summary

Adds coverage-aware reporting and filtering to `ivert validate`, plus a couple of small `_summary_stats.txt` improvements.

### Coverage summary statistics
When `-mc/--measure-coverage` is used, `_summary_stats.txt` now includes a decile section reporting the RMSE of grid cells above each coverage threshold (from 100% of cells down to the best-covered 10%). This shows how ICESat-2 coverage — and thus sampling bias — affects reported DEM accuracy.

### `--minimum-coverage-pct` / `-mcp` filter
New option on `ivert validate` that drops grid cells whose measured coverage is below a given percentage (0-100) from **all** outputs: the `_results.h5` dataframe, `_summary_stats.txt`, error exports, and plots.

- Requires `-mc/--measure-coverage`; using it without that flag raises a clear usage error.
- Value is constrained to the 0-100 range.
- Threaded through the single-DEM, multi-DEM (collection), and DEM-subdivision code paths. Because coverage is a per-cell property, per-subset filtering yields identical merged results.

### `_summary_stats.txt` polish
- Reduced excessive float precision to 2 decimal places (at least 2 significant digits for magnitudes below 0.10).
- Reordered so the "Number of cells with bathymetry photons" and "Mean roughness" lines appear above the "== Decile ranges of errors" section.

## Testing
- All three edited modules compile; ruff check/format pass.
- CLI verified: option appears in `--help`, the `-mc`-required guard fires, and out-of-range values are rejected.
- Filtering verified end-to-end against a synthetic results dataframe (a ≥50% threshold retained exactly the expected cells).
- No existing unit tests cover this path (the `src/tests/` files are integration download scripts).