### PR TITLE
Add tables (PyTables) to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "scipy",
     "shapely",
     "six",
+    "tables",
     "tabulate",
     "xarray",
     "fetchez",


### PR DESCRIPTION
## Summary

`pandas.read_hdf` / `to_hdf` calls in `validate_dem_collection.py` and `plot_results_slope_centrality.py` require PyTables, which was not a declared dependency. Clean installs crashed with `ModuleNotFoundError: No module named 'tables'` when running `ivert validate`.

This PR adds `tables` to the `dependencies` list in `pyproject.toml`.

## Notes

- The conda-forge recipe also needs the equivalent `pytables` package added to `requirements.run`. That change is staged separately in the `ivert-feedstock` repo and will go in alongside the next version bump.

Fixes #53