### PR TITLE
Add 'ivert classes' command and centralize photon class definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Developed by the [CIRES Coastal DEM Team](https://ciresdem.github.io). Primary a
 - Automatically-generated plots of DEM accuracies compared to ICESat-2.
 - Export errors to GeoTIFF, GeoPackage, Shapefile, or XYZ text
 - Local photon database management — download once, validate many times
+- Export classified photons from the database to GeoPackage, Shapefile, or XYZ text
 
 ---
 
@@ -71,6 +72,7 @@ ivert validate mydem.tif
 |---------|-------------|
 | [ivert setup](docs/setup.md) | Create data directories and set up NASA Earthdata credentials |
 | [ivert validate](docs/validate.md) | Validate DEMs against ICESat-2 data |
-| [ivert database](docs/database.md) | Download and manage the local photon database |
+| [ivert database](docs/database.md) | Download, export, and manage the local photon database |
+| [ivert classes](docs/classes.md) | List the ICESat-2 photon classification codes |
 | [ivert cache](docs/cache.md) | View and clear the local file cache |
 | [ivert options](docs/options.md) | View and change configuration settings |

--- a/docs/classes.md
+++ b/docs/classes.md
@@ -1,0 +1,35 @@
+# ivert classes
+
+List the ICESat-2 photon classification codes and their meanings. These are the codes IVERT assigns to photons during classification and that you use when filtering photons — for example with the `--classes` option of [`ivert database download`](database.md#photon-class-options) and [`ivert database export`](database.md#filtering-options).
+
+```
+ivert classes
+```
+
+This command takes no options. It prints the current code table:
+
+| Code | Description |
+|------|-------------|
+| `0` | Noise (if enabled) |
+| `1` | Ground (ATL08) |
+| `2` | Canopy (ATL08) |
+| `3` | Top Canopy (ATL08) |
+| `6` | Land Ice (ATL06) |
+| `7` | Buildings (Dynamic Algo / Bing Mask) |
+| `40` | Seafloor (ATL24 / Dynamic Algo) |
+| `41` | Nearshore Water Surface (ATL24 / Dynamic Algo) |
+| `42` | Inland Water Surface (ATL13 / Dynamic Algo) |
+| `44` | Open Ocean Surface (ATL12 / Geoid Fallback) |
+| `-1` | Unclassified |
+
+The definitions are read from the [globato](https://github.com/continuous-dems/globato) ICESat-2 reader, so they always match the classifier IVERT uses. Run `ivert classes` to see the authoritative list for your installed version.
+
+---
+
+## Example
+
+```bash
+# List the photon class codes, then download only ground and seafloor photons
+ivert classes
+ivert database download -c 1/40 -- -74.0/-73.0/40.5/41.0
+```

--- a/docs/database.md
+++ b/docs/database.md
@@ -7,6 +7,7 @@ Manage the local IVERT ICESat-2 photon database. IVERT stores downloaded photon 
 ## Subcommands
 
 - [`ivert database download`](#download) — download new ICESat-2 data
+- [`ivert database export`](#export) — export photons to GIS vector formats
 - [`ivert database list`](#list) — list what's already downloaded
 - [`ivert database size`](#size) — check disk usage
 - [`ivert database rebuild`](#rebuild) — rebuild the index from existing files
@@ -89,6 +90,62 @@ Photon class codes:
 | `-p, --projection TEXT` | Horizontal CRS of the bounding box (default: `EPSG:4326`) |
 | `-r, --replace` | Replace any previously downloaded data overlapping this region |
 | `-f, --force` | Skip the interactive prompt when the date range extends beyond the ATL24 data cutoff |
+
+---
+
+## export
+
+Export photons from the database to common GIS vector formats. Each exported photon carries its full set of fields: `x`, `y`, `z`, `class_code`, `class_name`, `confidence`, `delta_time`, `granule_id`, and (where present) `bathy_confidence`.
+
+```
+ivert database export [BBOX_OR_FILE] [OPTIONS]
+```
+
+### Choosing what to export
+
+With no region argument, the **entire database** is exported. Optionally restrict the export to one geographic area — either a bounding box or a georeferenced file (a raster or a polygon-vector file) whose extent defines the region:
+
+```
+# Export the whole database (default output: ./ivert_photons.gpkg)
+ivert database export
+
+# Restrict to a bounding box: W/E/S/N (default order)
+ivert database export -- -74.0/-73.0/40.5/41.0
+
+# Use --wsen if your numbers are in W/S/E/N order
+ivert database export --wsen -- -74.0/40.5/-73.0/41.0
+
+# Use the extent of a raster or polygon-vector file
+ivert database export mydem.tif
+ivert database export coastline.gpkg
+```
+
+> **Note:** Because the region argument is variable-length, put any options *before* a `--` delimiter when the bounding box begins with a negative number (e.g. `ivert database export -c 40/41 -- -74.0/-73.0/40.5/41.0`).
+
+### Output format options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-of, --output-format FORMATS` | `gpkg` | Vector format(s): `gpkg`, `shp`, `xyz`, or a comma-separated combination (e.g. `gpkg,shp`) |
+| `-o, --output PATH` | `./ivert_photons` | Output file path. The correct extension is added per format, so multiple formats share this base name |
+| `-ow, --overwrite` | | Overwrite existing output files (otherwise formats whose file already exists are skipped) |
+
+Shapefiles (`shp`) drop the `class_name` and `granule_id` fields, which exceed the format's field-name/length limits; `gpkg` and `xyz` retain all fields.
+
+### Filtering options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-c, --classes TEXT` | all classes | Slash-separated photon class codes to include (e.g. `40/41`). See [class codes](#photon-class-options) above, or run `ivert classes` |
+| `-ds, --start-date TEXT` | no lower bound | Only export photons on or after this date. Accepts dateparser formats: `2023-01-01`, `"1 year ago"`, `20230101` |
+| `-de, --end-date TEXT` | no upper bound | Only export photons before this date |
+
+### Other options
+
+| Flag | Description |
+|------|-------------|
+| `-p, --projection TEXT` | Horizontal CRS of the bounding box (default: `EPSG:4326`) |
+| `-f, --force` | Skip the confirmation prompt when the export is estimated to be large |
 
 ---
 
@@ -177,4 +234,14 @@ ivert database download mydem.tif
 ```
 ivert database list
 ivert database size
+```
+
+**Export bathymetry photons for a region to GeoPackage and Shapefile:**
+```
+ivert database export -of gpkg,shp -c 40/41 -o bahamas_bathy -- -78.5/-77.0/24.0/25.5
+```
+
+**Export the whole database (all photons) to an XYZ text file:**
+```
+ivert database export -of xyz -o all_photons
 ```

--- a/src/ivert/cli.py
+++ b/src/ivert/cli.py
@@ -194,6 +194,44 @@ def _setup_earthdata_credentials():
     click.echo(f"Saved NASA Earthdata credentials to {netrc_path}.")
 
 
+@ivert_cli.command("classes")
+def classes():
+    """List the ICESat-2 photon classification codes and their meanings.
+
+    These are the class codes assigned to ICESat-2 photons during
+    classification and used when filtering photons for validation (e.g. the
+    ``--classes`` option of ``ivert database download``). Definitions come from
+    the globato ICESat-2 reader so they always match the classifier.
+    """
+    from ivert.photon_classes import photon_classes
+
+    try:
+        classes_list = photon_classes()
+    except ImportError:
+        raise click.ClickException(
+            "Could not import globato to read photon class definitions. "
+            "Ensure the globato package is installed.",
+        )
+
+    if not classes_list:
+        click.echo("No photon class definitions found.")
+        return
+
+    code_w = max(len("Code"), *(len(str(c)) for c, _ in classes_list))
+    header = click.style(f"{'Code':>{code_w}}  Description", bold=True)
+    click.echo(f"\n  {header}")
+    click.echo("  " + "-" * (code_w + 2 + 40))
+
+    for code, desc in classes_list:
+        colored_code = click.style(f"{code:>{code_w}}", fg="cyan", bold=True)
+        click.echo(f"  {colored_code}  {desc}")
+
+    click.echo(
+        "\n  These codes are used with the --classes option of "
+        "'ivert database download'.",
+    )
+
+
 @ivert_cli.command("setup")
 def setup():
     """Create IVERT's local data directories and check NASA Earthdata credentials.
@@ -760,13 +798,11 @@ def database_size():
 @click.option(
     "-c",
     "--classes",
-    default="1/6/7/9/40/41/42",
+    default="1/6/7/40/41/42/44",
     show_default=True,
     help=(
         "ICESat-2 photon classes to download, slash-separated. "
-        "-1=unclassified, 0=noise, 1=ground, 2=canopy, 3=canopy-top, "
-        "6=land-ice, 7=buildings, 9=inland-water, 40=bathy-floor, "
-        "41=bathy-surface, 42=lake-surface."
+        "Run 'ivert classes' for the full list of codes and their meanings."
     ),
 )
 @click.option(

--- a/src/ivert/cli.py
+++ b/src/ivert/cli.py
@@ -976,6 +976,372 @@ def database_download(
     )
 
 
+# Formats offered by 'ivert database export' (a subset of export_vector's
+# SUPPORTED_FORMATS; csv is intentionally omitted in favour of the GIS formats).
+_EXPORT_FORMATS = ("gpkg", "shp", "xyz")
+
+# Wide YYYYMMDD bounds used to select every granule when no date range is given.
+_EXPORT_DATE_MIN = 19000101
+_EXPORT_DATE_MAX = 99991231
+
+# Estimated-photon-count threshold above which 'ivert database export' prompts
+# for confirmation (unless -f/--force is given).
+_EXPORT_WARN_PHOTON_THRESHOLD = 25_000_000
+
+# Vector-file extensions whose extent can define an export region.
+_EXPORT_REGION_VECTOR_EXTENSIONS = (
+    ".shp",
+    ".geojson",
+    ".json",
+    ".gpkg",
+    ".gml",
+    ".kml",
+)
+
+
+def _wgs84_bbox_from_file(path):
+    """Return a WGS84 (xmin, xmax, ymin, ymax) bbox from a raster or polygon-vector file."""
+    ext = os.path.splitext(path)[1].lower()
+    if ext in _EXPORT_REGION_VECTOR_EXTENSIONS:
+        import geopandas
+
+        gdf = geopandas.read_file(path)
+        if gdf.crs is not None and gdf.crs.to_epsg() != 4326:
+            gdf = gdf.to_crs(epsg=4326)
+        minx, miny, maxx, maxy = (float(v) for v in gdf.total_bounds)
+        return (minx, maxx, miny, maxy)
+
+    # Otherwise treat it as a raster; the CRS is read from the file header.
+    from ivert.utils import dem_geom
+
+    return dem_geom.get_wgs84_bounding_box(path)
+
+
+def _region_to_wgs84_bbox(tokens, projection, wsen):
+    """Parse export-region tokens into a WGS84 (xmin, xmax, ymin, ymax) bbox.
+
+    Returns None when no tokens are given (i.e. export the entire database).
+    Tokens are either a 4-value slash-separated bounding box or a single path to
+    a georeferenced raster or polygon-vector file.
+    """
+    if not tokens:
+        return None
+
+    # Flatten slash-separated tokens into a flat list of values.
+    values = []
+    for token in tokens:
+        values.extend(token.split("/"))
+
+    # Try a 4-value numeric bounding box first.
+    if len(values) == 4:
+        try:
+            nums = [float(v) for v in values]
+        except ValueError:
+            nums = None
+
+        if nums is not None:
+            if wsen:
+                # W/S/E/N → xmin, ymin, xmax, ymax
+                xmin, ymin, xmax, ymax = nums
+            else:
+                # W/E/S/N → xmin, xmax, ymin, ymax
+                xmin, xmax, ymin, ymax = nums
+
+            if projection.upper() in ("EPSG:4326", "4326"):
+                return (xmin, xmax, ymin, ymax)
+
+            from ivert.utils import dem_geom
+
+            return dem_geom.get_wgs84_bounding_box(
+                (xmin, xmax, ymin, ymax),
+                dem_horz_reference_frame=projection,
+            )
+
+    # Otherwise the region must be a single georeferenced file.
+    if len(tokens) != 1:
+        raise click.ClickException(
+            "Region must be a 4-value bounding box or a single georeferenced file.",
+        )
+
+    path = tokens[0]
+    if not os.path.exists(path):
+        raise click.ClickException(
+            f"Region '{path}' is neither a valid 4-value bounding box nor an existing file.",
+        )
+
+    try:
+        return _wgs84_bbox_from_file(path)
+    except Exception as exc:
+        raise click.ClickException(
+            f"Could not read a bounding box from '{path}': {exc}",
+        ) from exc
+
+
+@database.command("export")
+@click.argument("bbox_or_file", nargs=-1, required=False)
+@click.option(
+    "-of",
+    "--output-format",
+    "output_format",
+    default="gpkg",
+    show_default=True,
+    metavar="FORMATS",
+    help=(
+        "Vector format(s) to export, drawn from 'gpkg', 'shp', 'xyz'. Pass a single "
+        "format or a comma-separated combination (e.g. 'gpkg,shp')."
+    ),
+)
+@click.option(
+    "-o",
+    "--output",
+    "output",
+    default=None,
+    metavar="PATH",
+    help=(
+        "Output file path. The correct extension is added per format, so multiple "
+        "formats share this base name. Default: 'ivert_photons' in the current directory."
+    ),
+)
+@click.option(
+    "-c",
+    "--classes",
+    "classes",
+    default=None,
+    metavar="CLASSES",
+    help=(
+        "Slash-separated photon class codes to include (e.g. '1/40/41'). "
+        "Default: all classes. Run 'ivert classes' for the full list of codes."
+    ),
+)
+@click.option(
+    "-ds",
+    "--start-date",
+    "--start_date",
+    "date_start",
+    default=None,
+    metavar="DATE",
+    help=(
+        "Only export photons on or after this date. Accepts any format supported by "
+        "Python's dateparser library (e.g. '2023.01.01', '1 year ago'). "
+        "Default: no lower date bound."
+    ),
+)
+@click.option(
+    "-de",
+    "--end-date",
+    "--end_date",
+    "date_end",
+    default=None,
+    metavar="DATE",
+    help=(
+        "Only export photons before this date. Accepts any format supported by "
+        "Python's dateparser library. Default: no upper date bound."
+    ),
+)
+@click.option(
+    "-p",
+    "--projection",
+    default="EPSG:4326",
+    show_default=True,
+    help="Horizontal projection (EPSG code) that the bounding-box coordinates are in.",
+)
+@click.option(
+    "--wsen",
+    is_flag=True,
+    default=False,
+    help=(
+        "Treat the bounding box as W/S/E/N order (lower-left, upper-right). "
+        "Default order is W/E/S/N (Xmin/Xmax/Ymin/Ymax)."
+    ),
+)
+@click.option(
+    "-ow",
+    "--overwrite",
+    is_flag=True,
+    default=False,
+    help="Overwrite existing output files. Default: skip formats whose file already exists.",
+)
+@click.option(
+    "-f",
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Skip the confirmation prompt when the export is estimated to be large.",
+)
+def database_export(
+    bbox_or_file,
+    output_format,
+    output,
+    classes,
+    date_start,
+    date_end,
+    projection,
+    wsen,
+    overwrite,
+    force,
+):
+    """Export IVERT ICESat-2 photons to GIS vector formats.
+
+    BBOX_OR_FILE (optional) restricts the export to one geographic area: either a
+    4-value bounding box in W/E/S/N order (slash-separated, e.g. -74/-73/40.5/41),
+    or a path to a georeferenced raster or polygon-vector file whose extent defines
+    the region. With no region given, the entire database is exported.
+
+    Each output carries the same per-photon fields as 'ivert database' stores
+    (x, y, z, class_code, class_name, confidence, delta_time, granule_id, and
+    bathy_confidence where present).
+
+    Examples:
+        ivert database export
+
+        ivert database export -of gpkg,shp -o bahamas_photons
+
+        ivert database export -- -74/-73/40.5/41 -c 40/41 -ds 2023.01.01 -de 2024.01.01
+
+        ivert database export coastline.gpkg -of xyz
+
+    (Note: Use the '--' delimiter to end command-line options if coordinates begin
+    with a negative '-')
+
+    """
+    from ivert import export_vector as ev
+    from ivert import icesat2_database_v2 as is2db_mod
+    from ivert.icesat2_database_v2 import _yyyymmdd_to_delta_time
+
+    verbose = logging.getLogger().level <= logging.INFO
+
+    # --- Parse output formats. ---
+    try:
+        fmt_keys = ev.normalize_format_keys(output_format, allowed=_EXPORT_FORMATS)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    # --- Parse class filter. ---
+    class_list = None
+    if classes:
+        try:
+            class_list = [
+                int(c) for c in classes.replace(",", "/").split("/") if c != ""
+            ]
+        except ValueError as exc:
+            raise click.ClickException(
+                f"Invalid --classes value '{classes}': {exc}",
+            ) from exc
+
+    # --- Parse region. ---
+    bbox = _region_to_wgs84_bbox(list(bbox_or_file), projection, wsen)
+
+    # --- Open the database index. ---
+    db = is2db_mod.IS2Database()
+    gdf_index = db.open_gdf(verbose=False)
+    if gdf_index is None or len(gdf_index) == 0:
+        raise click.ClickException(
+            f"No IVERT database found (or it is empty) at: {db.db_fname}\n"
+            "Run 'ivert database download <bbox>' to create one.",
+        )
+
+    # --- Parse the optional date range. ---
+    date_filtering = date_start is not None or date_end is not None
+    tmin, tmax = _EXPORT_DATE_MIN, _EXPORT_DATE_MAX
+    if date_filtering:
+        try:
+            if date_start is not None:
+                tmin = db.convert_date_to_yyyymmdd(date_start)
+            if date_end is not None:
+                tmax = db.convert_date_to_yyyymmdd(date_end)
+        except Exception as exc:
+            raise click.ClickException(f"Could not parse date: {exc}") from exc
+        if tmin >= tmax:
+            raise click.ClickException(
+                f"--start-date ({tmin}) must be before --end-date ({tmax}).",
+            )
+
+    # --- Select the granules to read. ---
+    if bbox is None and not date_filtering:
+        granule_rows = gdf_index
+    else:
+        spatial = bbox if bbox is not None else (-180.0, 180.0, -90.0, 90.0)
+        bbox6 = (spatial[0], spatial[1], spatial[2], spatial[3], tmin, tmax)
+        granule_rows = db.query_granules(bbox6)
+        if granule_rows is None:
+            granule_rows = gdf_index.iloc[0:0]
+
+    if len(granule_rows) == 0:
+        raise click.ClickException(
+            "No granules found matching the requested region and/or date range.",
+        )
+
+    # --- Warn on large exports. ---
+    est_photons = (
+        int(granule_rows["numphotons"].sum())
+        if "numphotons" in granule_rows.columns
+        else 0
+    )
+    if est_photons >= _EXPORT_WARN_PHOTON_THRESHOLD and not force:
+        scope = "the entire database" if bbox is None else "the requested region"
+        click.echo(
+            f"WARNING: Exporting {scope} covers {len(granule_rows):,} granule(s) with up "
+            f"to ~{est_photons:,} photons. This may produce very large output file(s) and "
+            f"take a while.",
+            err=True,
+        )
+        if not click.confirm("\nContinue with the export anyway?", default=False):
+            raise click.Abort()
+
+    # --- Read, subset, and merge granules. ---
+    import geopandas
+    import pandas
+
+    dt_min = _yyyymmdd_to_delta_time(tmin) if date_filtering else None
+    dt_max = _yyyymmdd_to_delta_time(tmax) if date_filtering else None
+
+    total = len(granule_rows)
+    click.echo(f"Reading {total:,} granule(s) ...")
+
+    gdfs = []
+    photon_count = 0
+    for i, (_, row) in enumerate(granule_rows.iterrows(), start=1):
+        fpath = os.path.join(db.granules_dir, row["filename"])
+        if not os.path.exists(fpath):
+            click.echo(f"  Skipping missing granule file: {row['filename']}", err=True)
+            continue
+
+        gdf = ev.nc_to_geodataframe(fpath, classes=class_list)
+        if bbox is not None:
+            gdf = ev.subset_gdf_to_bbox(gdf, bbox)
+        if date_filtering:
+            gdf = ev.subset_gdf_to_date_range(gdf, dt_min, dt_max)
+
+        if len(gdf) > 0:
+            gdfs.append(gdf)
+            photon_count += len(gdf)
+
+        if verbose:
+            click.echo(f"  [{i}/{total}] {row['filename']}: {len(gdf):,} photons")
+
+    if not gdfs:
+        raise click.ClickException("No photons found to export after filtering.")
+
+    merged = geopandas.GeoDataFrame(
+        pandas.concat(gdfs, ignore_index=True),
+        crs=ev.WGS84_EPSG,
+    )
+
+    # --- Write the requested format(s). ---
+    out_base = output or os.path.join(os.getcwd(), "ivert_photons")
+    written = ev.write_vector_multi(merged, out_base, fmt_keys, overwrite=overwrite)
+
+    if not written:
+        click.echo(
+            "\nNo files written (all target files already exist; use -ow to overwrite).",
+        )
+        return
+
+    click.echo(f"\nExported {len(merged):,} photons to {len(written)} file(s):")
+    for path in written:
+        click.echo(f"  {path}")
+
+
 ###############################################################
 # cache
 ###############################################################

--- a/src/ivert/export_vector.py
+++ b/src/ivert/export_vector.py
@@ -1,34 +1,15 @@
 #!/usr/bin/env python3
-"""ivert_output_vector.py — convert IVERT ICESat-2 .nc granule files to GIS vector formats.
+"""export_vector — convert IVERT ICESat-2 .nc granule files to GIS vector formats.
 
-Reads one or more .nc files produced by IS2Database._process_h5_to_nc() and
-writes them as geolocated point vector files (GeoPackage, Shapefile, or CSV/XYZ).
+Reads .nc files produced by IS2Database._process_h5_to_nc() and writes them as
+geolocated point vector files (GeoPackage, Shapefile, or CSV/XYZ).
 
-Usage
------
-    python ivert_output_vector.py <nc_file_or_dir> [<nc_file_or_dir> ...] [options]
-
-Examples
---------
-    # Single file to GeoPackage (default)
-    python ivert_output_vector.py granule.nc
-
-    # All .nc files in a directory, output as Shapefile alongside inputs
-    python ivert_output_vector.py ~/.ivert/icesat2/granules/ -of shp
-
-    # Filter to bathy photons only, send to a specific directory
-    python ivert_output_vector.py granule.nc --classes 40,41 -d /tmp/out/
-
-    # Merge all inputs into one output file
-    python ivert_output_vector.py granules/ --merge -o merged_bahamas.gpkg
-
+This module is the library backing the 'ivert database export' command; it has
+no command-line interface of its own.
 """
 
-import glob
 import os
-import sys
 
-import click
 import geopandas
 import netCDF4
 import numpy as np
@@ -128,7 +109,7 @@ def write_vector(
     if os.path.exists(outpath):
         if not overwrite:
             print(
-                f"  Skipping existing {os.path.basename(outpath)} (use -w to overwrite).",
+                f"  Skipping existing {os.path.basename(outpath)} (use -ow to overwrite).",
             )
             return
         os.remove(outpath)
@@ -150,137 +131,113 @@ def write_vector(
 
 
 # ---------------------------------------------------------------------------
-# File discovery
+# Multi-format helpers (used by 'ivert database export')
 # ---------------------------------------------------------------------------
-def collect_nc_files(paths: list) -> list:
-    """Expand a list of file/directory paths into a flat list of .nc files."""
-    found = []
-    for p in paths:
-        if os.path.isdir(p):
-            found.extend(sorted(glob.glob(os.path.join(p, "*.nc"))))
-        elif os.path.isfile(p) and p.endswith(".nc"):
-            found.append(p)
-        else:
-            # Treat as glob pattern
-            matches = sorted(glob.glob(p))
-            found.extend(m for m in matches if m.endswith(".nc"))
-    return found
+def normalize_format_keys(output_format: str, allowed=None) -> list:
+    """Parse a comma-separated output-format string into a validated list of format keys.
 
+    Parameters
+    ----------
+    output_format : str
+        One format key or a comma-separated combination (e.g. "gpkg,shp,xyz").
+    allowed : iterable of str, optional
+        Restrict which format keys are accepted. Defaults to every key in
+        SUPPORTED_FORMATS.
 
-# ---------------------------------------------------------------------------
-# CLI
-# ---------------------------------------------------------------------------
-@click.command(
-    help="Convert IVERT ICESat-2 .nc granule files to GIS vector formats.",
-    epilog=__doc__,
-)
-@click.argument("inputs", nargs=-1, required=True)
-@click.option(
-    "-of",
-    "--output_format",
-    default="gpkg",
-    type=click.Choice(list(SUPPORTED_FORMATS.keys())),
-    help="Output format. Default: gpkg",
-)
-@click.option(
-    "-d",
-    "--output_dir",
-    default=None,
-    help="Output directory. Default: same directory as each input file.",
-)
-@click.option(
-    "-o",
-    "--output",
-    default=None,
-    help="Explicit output filename (only valid with --merge or a single input).",
-)
-@click.option(
-    "--merge",
-    is_flag=True,
-    default=False,
-    help="Merge all input granules into a single output file.",
-)
-@click.option(
-    "--classes",
-    "classes_str",
-    default=None,
-    help="Comma-separated class codes to include (e.g. '1,40,41'). "
-    "Default: all classes.",
-)
-@click.option(
-    "-w",
-    "--overwrite",
-    is_flag=True,
-    default=False,
-    help="Overwrite existing output files.",
-)
-def main(inputs, output_format, output_dir, output, merge, classes_str, overwrite):
-    """Convert IVERT ICESat-2 .nc granule files to GIS vector formats.
+    Returns
+    -------
+    list of str
+        The format keys in the order given, with duplicates removed.
 
-    INPUTS is one or more .nc file(s) or director(y/ies) containing .nc files.
+    Raises
+    ------
+    ValueError
+        If no format is given or an unsupported format is requested.
+
     """
-    fmt_key = output_format.lower().lstrip(".")
+    allowed = tuple(SUPPORTED_FORMATS) if allowed is None else tuple(allowed)
+
+    keys = []
+    for token in str(output_format).split(","):
+        key = token.strip().lower().lstrip(".")
+        if not key:
+            continue
+        if key not in allowed:
+            raise ValueError(
+                f"Unsupported output format '{token.strip()}'. "
+                f"Choose from: {', '.join(allowed)}.",
+            )
+        if key not in keys:
+            keys.append(key)
+
+    if not keys:
+        raise ValueError("No output format specified.")
+    return keys
+
+
+def subset_gdf_to_bbox(gdf: geopandas.GeoDataFrame, bbox) -> geopandas.GeoDataFrame:
+    """Return the subset of a photon GeoDataFrame whose points fall within a bbox.
+
+    bbox is (xmin, xmax, ymin, ymax) in the GeoDataFrame's own CRS. The maximum
+    edges are exclusive, matching the IS2Database photon-query convention.
+    """
+    if gdf.empty:
+        return gdf
+    xmin, xmax, ymin, ymax = bbox
+    x = gdf["x"]
+    y = gdf["y"]
+    mask = (x >= xmin) & (x < xmax) & (y >= ymin) & (y < ymax)
+    return gdf[mask].reset_index(drop=True)
+
+
+def subset_gdf_to_date_range(
+    gdf: geopandas.GeoDataFrame,
+    dt_min: float,
+    dt_max: float,
+) -> geopandas.GeoDataFrame:
+    """Return the subset of a photon GeoDataFrame within a delta_time range.
+
+    dt_min and dt_max are ICESat-2 delta_time values (seconds since 2018-01-01).
+    The upper bound is exclusive, matching IS2Database.read_granule().
+    """
+    if gdf.empty or "delta_time" not in gdf.columns:
+        return gdf
+    dt = gdf["delta_time"]
+    mask = (dt >= dt_min) & (dt < dt_max)
+    return gdf[mask].reset_index(drop=True)
+
+
+def output_path_for_format(out_base: str, fmt_key: str) -> str:
+    """Build the output path for a format by giving out_base the format's extension.
+
+    Any recognized vector extension already on out_base is stripped first, so a
+    base of 'photons.gpkg' combined with the 'shp' format yields 'photons.shp'.
+    """
     _, ext = SUPPORTED_FORMATS[fmt_key]
+    stem = out_base
+    for _driver, known_ext in SUPPORTED_FORMATS.values():
+        if stem.lower().endswith(known_ext):
+            stem = stem[: -len(known_ext)]
+            break
+    return stem + ext
 
-    classes = None
-    if classes_str:
-        classes = [int(c.strip()) for c in classes_str.split(",")]
 
-    nc_files = collect_nc_files(list(inputs))
-    if not nc_files:
-        sys.exit("No .nc files found.")
+def write_vector_multi(
+    gdf: geopandas.GeoDataFrame,
+    out_base: str,
+    fmt_keys,
+    overwrite: bool = False,
+) -> list:
+    """Write a GeoDataFrame to one or more vector formats.
 
-    if output_dir and not os.path.isdir(output_dir):
-        sys.exit(f"Output directory does not exist: {output_dir}")
-
-    # ------------------------------------------------------------------
-    # Merged mode: combine all granules into one output file
-    # ------------------------------------------------------------------
-    if merge:
-        gdfs = []
-        for nc_path in nc_files:
-            print(f"Reading {os.path.basename(nc_path)} ...", flush=True)
-            gdf = nc_to_geodataframe(nc_path, classes=classes)
-            print(f"  {len(gdf):,} photons")
-            gdfs.append(gdf)
-
-        if not gdfs:
-            sys.exit("No photons found after filtering.")
-
-        merged = geopandas.GeoDataFrame(
-            pd.concat(gdfs, ignore_index=True),
-            crs=WGS84_EPSG,
-        )
-
-        if output:
-            outpath = output
-        else:
-            outdir = output_dir or os.path.dirname(nc_files[0])
-            outpath = os.path.join(outdir, "merged" + ext)
-
-        write_vector(merged, outpath, fmt_key, overwrite=overwrite)
-        return
-
-    # ------------------------------------------------------------------
-    # Per-file mode
-    # ------------------------------------------------------------------
-    if output and len(nc_files) > 1:
-        sys.exit("--output requires exactly one input file (or use --merge).")
-
-    for nc_path in nc_files:
-        print(f"\n{os.path.basename(nc_path)}", flush=True)
-        gdf = nc_to_geodataframe(nc_path, classes=classes)
-        print(f"  {len(gdf):,} photons")
-
-        if output:
-            outpath = output
-        else:
-            stem = os.path.splitext(os.path.basename(nc_path))[0]
-            outdir = output_dir or os.path.dirname(nc_path)
-            outpath = os.path.join(outdir, stem + ext)
-
+    Returns the list of file paths written (skipped existing files are omitted).
+    """
+    written = []
+    for fmt_key in fmt_keys:
+        outpath = output_path_for_format(out_base, fmt_key)
+        existed = os.path.exists(outpath)
         write_vector(gdf, outpath, fmt_key, overwrite=overwrite)
-
-
-if __name__ == "__main__":
-    main()
+        # write_vector() skips silently when the file exists and overwrite is False.
+        if not existed or overwrite:
+            written.append(outpath)
+    return written

--- a/src/ivert/export_vector.py
+++ b/src/ivert/export_vector.py
@@ -37,18 +37,6 @@ import pandas as pd
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
-CLASS_NAMES = {
-    0: "noise",
-    1: "ground",
-    2: "canopy",
-    3: "canopy_top",
-    6: "ice_surface",
-    7: "building",
-    40: "bathy_floor",
-    41: "bathy_surface",
-    42: "inland_water_surface",
-}
-
 SUPPORTED_FORMATS = {
     "gpkg": ("GPKG", ".gpkg"),
     "shp": ("ESRI Shapefile", ".shp"),
@@ -73,6 +61,10 @@ def nc_to_geodataframe(nc_path: str, classes: list = None) -> geopandas.GeoDataF
         If given, keep only photons whose class_code is in this list.
 
     """
+    from ivert.photon_classes import class_names as _class_names
+
+    class_names = _class_names()
+
     with netCDF4.Dataset(nc_path) as ds:
 
         def _arr(name):
@@ -104,7 +96,7 @@ def nc_to_geodataframe(nc_path: str, classes: list = None) -> geopandas.GeoDataF
             "z": z,
             "class_code": class_code,
             "class_name": pd.array(
-                [CLASS_NAMES.get(c, f"class_{c}") for c in class_code],
+                [class_names.get(c, f"class_{c}") for c in class_code],
                 dtype="string",
             ),
             "confidence": confidence,

--- a/src/ivert/photon_classes.py
+++ b/src/ivert/photon_classes.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+
+"""ivert.photon_classes
+~~~~~~~~~~~~~~~~~~~~~~
+Single source of truth for ICESat-2 photon classification codes.
+
+The authoritative definitions live in globato's ``ATL03Reader.meta_desc``
+docstring. Parsing them here keeps IVERT's CLI help, vector exports, and plot
+legends in sync with the upstream classifier instead of each module carrying its
+own (drift-prone) copy of the code list.
+"""
+
+import functools
+import re
+
+
+@functools.lru_cache(maxsize=1)
+def photon_classes():
+    """Return ``((code, description), ...)`` in the order globato lists them.
+
+    Parsed from globato's ``ATL03Reader.meta_desc`` docstring. Raises
+    ``ImportError`` if globato is not installed.
+    """
+    from globato.streams.readers.icesat2 import ATL03Reader
+
+    classes = []
+    for line in ATL03Reader.meta_desc.splitlines():
+        match = re.match(r"^\s*(-?\d+)\s*:\s*(.+?)\s*$", line)
+        if match:
+            classes.append((int(match.group(1)), match.group(2)))
+    return tuple(classes)
+
+
+def class_descriptions():
+    """Return ``{code: description}`` (the full upstream text) per class."""
+    return dict(photon_classes())
+
+
+def _short(description):
+    """Strip parenthetical qualifiers and any '/'-separated alternates.
+
+    e.g. ``"Coastline / Nearshore Water (ATL24 / Dynamic Algo)"`` -> ``"Coastline"``.
+    """
+    return re.sub(r"\(.*?\)", "", description).split("/")[0].strip()
+
+
+def class_labels():
+    """Return ``{code: short human label}``, e.g. ``41 -> "Coastline"``."""
+    return {code: _short(desc) for code, desc in photon_classes()}
+
+
+def class_names():
+    """Return ``{code: short snake_case name}``, e.g. ``41 -> "coastline"``."""
+    return {
+        code: "_".join(_short(desc).split()).lower() for code, desc in photon_classes()
+    }

--- a/src/ivert/plot_photon_clouds_v2.py
+++ b/src/ivert/plot_photon_clouds_v2.py
@@ -10,13 +10,8 @@ If the matching ATL03 .h5 file is available (searched in the same directory and
 in the ivert cache), it splits photons by beam and plots one curtain per beam.
 Without the .h5, all photons are plotted together sorted by latitude.
 
-Class codes (current convention):
-     1 = ground/land
-     2 = canopy
-     3 = canopy top
-     7 = built structure
-    40 = bathy floor (seafloor)
-    41 = bathy surface (water surface)
+Photon class codes and their meanings come from globato's ATL03 reader; run
+'ivert classes' (or see ivert.photon_classes) for the authoritative list.
 """
 
 import glob
@@ -32,20 +27,24 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import netCDF4
 
+from ivert.photon_classes import class_labels
+
 # ---------------------------------------------------------------------------
 # Style
 # ---------------------------------------------------------------------------
+# Visual attributes only; legend labels come from ivert.photon_classes so they
+# stay in sync with the globato classifier.
 CLASS_STYLE = {
-    0: dict(color="grey", label="Noise", zorder=0.5, alpha=0.5, s=1),
-    1: dict(color="saddlebrown", label="Ground", zorder=2, alpha=1.0, s=3),
-    2: dict(color="limegreen", label="Canopy", zorder=1, alpha=0.8, s=2),
-    3: dict(color="forestgreen", label="Canopy Top", zorder=2, alpha=0.9, s=2),
-    7: dict(color="red", label="Built Structure", zorder=2, alpha=0.8, s=2),
-    40: dict(color="darkorange", label="Bathy Floor", zorder=3, alpha=1.0, s=3),
-    41: dict(color="dodgerblue", label="Water Surface", zorder=1, alpha=0.6, s=1),
-    42: dict(color="dodgerblue", label="Inland Water", zorder=1, alpha=0.6, s=1),
+    0: dict(color="grey", zorder=0.5, alpha=0.5, s=1),
+    1: dict(color="saddlebrown", zorder=2, alpha=1.0, s=3),
+    2: dict(color="limegreen", zorder=1, alpha=0.8, s=2),
+    3: dict(color="forestgreen", zorder=2, alpha=0.9, s=2),
+    7: dict(color="red", zorder=2, alpha=0.8, s=2),
+    40: dict(color="darkorange", zorder=3, alpha=1.0, s=3),
+    41: dict(color="dodgerblue", zorder=1, alpha=0.6, s=1),
+    42: dict(color="dodgerblue", zorder=1, alpha=0.6, s=1),
 }
-DEFAULT_STYLE = dict(color="lightgrey", label="Other", zorder=0, alpha=0.3, s=1)
+DEFAULT_STYLE = dict(color="lightgrey", zorder=0, alpha=0.3, s=1)
 
 DEM_COLORS = ["dimgrey", "purple", "darkcyan", "darkmagenta", "darkgoldenrod"]
 
@@ -411,14 +410,16 @@ def plot_beam(
 
     fig, ax = plt.subplots(figsize=(12, 4))
 
+    labels = class_labels()
     for code in np.unique(cc):
         mask = cc == code
         style = CLASS_STYLE.get(int(code), DEFAULT_STYLE)
+        label = labels.get(int(code), "Other")
         ax.scatter(
             along_track[mask],
             z[mask],
             c=style["color"],
-            label=f"{style['label']} (n={mask.sum():,})",
+            label=f"{label} (n={mask.sum():,})",
             zorder=style["zorder"],
             alpha=style["alpha"],
             s=style["s"],


### PR DESCRIPTION
## Summary

Adds a top-level `ivert classes` command that lists the ICESat-2 photon classification codes and their meanings, and eliminates the duplicated class definitions that had drifted out of sync across the codebase.

## Changes

- **New `ivert classes` command** — prints each photon class code and its description.
- **New `src/ivert/photon_classes.py`** — single source of truth. Parses the definitions from globato's `ATL03Reader.meta_desc` so IVERT stays in sync with the upstream classifier. Exposes `photon_classes()`, `class_descriptions()`, `class_labels()`, and `class_names()`.
- **Removed drift-prone duplicates:**
  - `export_vector.py` — deleted the hard-coded `CLASS_NAMES` dict; now uses `class_names()`.
  - `cli.py` download `--classes` help — replaced the hand-maintained code list with a pointer to `ivert classes`.
  - `plot_photon_clouds_v2.py` — dropped the class list in the header comment and the `label=` entries baked into `CLASS_STYLE`; legend labels now come from `class_labels()` (colors/z-order unchanged).
- **`database download` default classes** updated `1/6/7/9/40/41/42` → `1/6/7/40/41/42/44`: drop `9` (not a class globato assigns) and add `44` (Open Ocean Surface).

## Companion label changes (globato)

Because definitions are now sourced from globato, the water/seafloor class **labels** are being clarified upstream in [continuous-dems/globato#133](https://github.com/continuous-dems/globato/pull/133):

| Code | globato label |
|---|---|
| 40 | Seafloor |
| 41 | Nearshore Water Surface |
| 42 | Inland Water Surface |
| 44 | Open Ocean Surface |

Once that merges and the installed globato updates, `ivert classes`, exported `class_name` strings, and plot legends reflect these automatically — no further IVERT change required.

## Behavioral notes

- New downloads now include class `44` (Open Ocean Surface) photons and no longer request the inert `9`. Existing local databases are unaffected.
- Exported `class_name` attribute strings now derive from globato rather than the old hard-coded names. With globato#133, the resulting names are `canopy_top`→`top_canopy`, `building`→`buildings`, `bathy_floor`→`seafloor`, `bathy_surface`→`nearshore_water_surface` (`inland_water_surface` is unchanged). Anything downstream that parses those strings should be aware.

## Testing

- `ivert classes` and `ivert database download --help` verified.
- `ruff check src` and `ruff format --check` pass (all pre-commit hooks pass).
