### PR TITLE
Update README installation and Capabilities sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,36 +3,44 @@
 
 IVERT validates Digital Elevation Models (DEMs) by comparing their elevations against ICESat-2 satellite photon data. It supports topographic, bathymetric, and mixed coastal DEMs, runs fully offline on any machine, and handles vertical datum conversions automatically.
 
-Developed by the [CIRES Coastal DEM Team](https://ciresdem.github.io). Primary authors: [Mike MacFerrin](https://github.com/mmacferrin) (IVERT) and [Matthew Love](https://github.com/matth-love) ([continuous-dems](https://github.com/continuous-dems) utilities).
+Developed by the [continuous-dems team](https://github.com/continuous-dems). Primary authors: [Mike MacFerrin](https://github.com/mmacferrin) (IVERT) and [Matthew Love](https://github.com/matth-love) ([continuous-dems](https://github.com/continuous-dems) utilities).
 
 ---
 ## Capabilities
 
-- Validate topographic, bathymetric, and coastal DEMs against ICESat-2 ATL03/ATL24 photons
-- Combines [ATL03](https://nsidc.org/data/atl03/)/[ATL08](https://nsidc.org/data/atl08/)/[ATL13](https://nsidc.org/data/atl13/)/[ATL24](https://nsidc.org/data/atl24/) for photon-level classifications, plus external datasets (such as the [Global Buildings Atlas](https://tubvsig-so2sat-vm1.srv.mwn.de/)) to classify built structures.
-- Additional coastline filtering to minimize false-positive ATL08 "ground" photons appearing offshore over water, and unreasonably-shallow "bathy floor" photons with large errors over deep water.
-- Automatic vertical datum conversions (NAVD88, EGM2008, MLLW, and many more)
-- Configurable photon confidence and quality filtering
-- Statistical outputs: bias, RMSE, NMAD, per-cell error maps
-- Automatically-generated plots of DEM accuracies compared to ICESat-2.
-- Export errors to GeoTIFF, GeoPackage, Shapefile, or XYZ text
-- Local photon database management — download once, validate many times
-- Export classified photons from the database to GeoPackage, Shapefile, or XYZ text
+- Validate topographic, bathymetric, and mixed coastal DEMs against ICESat-2 photons — a single DEM, or a whole directory/glob of DEMs with combined collection-level summaries.
+- Classifies photons by surface type — ground, canopy, land ice, buildings, seafloor, and water surfaces — by combining multiple ICESat-2 products ([ATL03](https://nsidc.org/data/atl03/), [ATL06](https://nsidc.org/data/atl06/), [ATL08](https://nsidc.org/data/atl08/), [ATL12](https://nsidc.org/data/atl12/), [ATL13](https://nsidc.org/data/atl13/), [ATL24](https://nsidc.org/data/atl24/)) with a Bing-derived building-footprint mask to flag built structures.
+- Coastline/water filtering to minimize false-positive "ground" photons appearing offshore over water and unreasonably-shallow "bathy floor" photons with large errors over deep water.
+- Automatic vertical datum conversion (NAVD88, EGM2008, MLLW, ellipsoid, and many more, by EPSG code or short name) — no manual reprojection needed.
+- Configurable photon filtering at both download and validation: signal confidence, bathymetry confidence, photon class selection, and outlier rejection.
+- Statistical outputs: mean bias, RMSE, standard deviation, a full percentile breakdown of per-cell errors, and optional per-cell photon coverage.
+- Automatically-generated validation plots (per-DEM and collection-wide).
+- Export per-cell errors to GeoTIFF, GeoPackage, Shapefile, or XYZ text.
+- Local, spatially-indexed photon database — download once, validate many times — with commands to list, size, rebuild, and delete cached data.
+- Export classified photons from the database to GeoPackage, Shapefile, or XYZ text.
+- Runs fully offline on any machine, with configurable data directories and per-project config profiles.
 
 ---
 
 ## Installation
 
+Available on [PyPI](https://pypi.org/project/ivert/):
+
 ```bash
 pip install ivert
 ```
-(^ coming soon)
+
+or on [conda-forge](https://anaconda.org/conda-forge/ivert):
+
+```bash
+conda install ivert
+```
 
 For development (editable install from this repo):
 
 ```bash
-git clone https://github.com/ciresdem/IVERT.git
-cd IVERT
+git clone https://github.com/continuous-dems/ivert.git
+cd ivert
 pip install -e .
 ```
 


### PR DESCRIPTION
Refreshes the outdated **Installation** and **Capabilities** sections of the main README.

### Installation
- Document `pip install ivert` and `conda install ivert` (removed the "coming soon" note), with links to the [PyPI](https://pypi.org/project/ivert/) and [conda-forge](https://anaconda.org/conda-forge/ivert) package pages.
- Point the development clone at `continuous-dems/ivert.git` (was the old `ciresdem/IVERT.git`).
- Fix the broken "CIRES Coastal DEM Team" link to point at the [continuous-dems](https://github.com/continuous-dems) GitHub org.

### Capabilities
Rewrote the bullet list to match the current docs and code:
- Corrected the building-footprint source to the Bing-derived mask (the old "Global Buildings Atlas" link was dead).
- Broadened the listed ICESat-2 products to include ATL06 and ATL12.
- Replaced NMAD (not actually computed) with the statistics IVERT reports: mean bias, RMSE, standard deviation, and percentile breakdown.
- Added previously-undocumented capabilities: batch/collection validation, per-cell photon coverage, download- and validation-stage filtering, database management commands, and per-project config profiles.