### PR TITLE
Add CHANGELOG.md with back-filled 0.6.x release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,85 @@
+# Changelog
+
+All notable changes to IVERT are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.6.6] - 2026-07-20
+
+### Added
+- `ivert classes` command listing ICESat-2 photon classification codes and their meanings (#55).
+- `ivert database export` command to export photons to vector formats (GeoPackage, Shapefile, XYZ, and more), with filtering by bounding box, photon class, and date range; supports defining an export region from a vector file's extent and prompts before exporting very large photon counts (#56).
+- Documentation: `docs/classes.md` and `docs/database.md` (#55).
+
+### Changed
+- Centralized photon-class definitions into `photon_classes.py`, removing duplicated constants across the codebase (#55).
+- Refactored `export_vector.py` for a cleaner, smaller implementation (#55).
+- Updated README installation and Capabilities sections (#55, #57).
+
+## [0.6.5] - 2026-07-19
+
+### Added
+- Added `tables` (PyTables) to dependencies (#54).
+
+## [0.6.4] - 2026-07-19
+
+### Added
+- `ivert setup` command for configuring data directories and Earthdata credentials (#46).
+- Coverage summary stats and `--minimum-coverage-pct` filter for `ivert validate` (#50).
+- Descriptions for `ivert options` commands (#49).
+
+### Changed
+- `ivert validate -ex` bounding boxes now default to W/E/S/N order, with a `--wsen` flag (#51).
+- Kept `ivert_results_subdir` relative in the config attribute and options list (#47).
+- Updated README (#52).
+
+### Removed
+- Redundant `_ICESat2_error_raster.tif` output (#48).
+
+## [0.6.3] - 2026-07-17
+
+### Changed
+- Cross-platform compatibility fixes for Windows and macOS (#43).
+- Replaced Linux-specific shell dependencies (#42).
+
+### Removed
+- `ivert upgrade` command (#42).
+- Unused config keys and orphaned version module (#44).
+
+## [0.6.2] - 2026-07-17
+
+### Added
+- `-ow`/`--overwrite` and `-ex`/`--exclude` flags for `ivert validate` (#36).
+- `ice_surface` and `inland_water_surface` photon classes (#32).
+
+### Changed
+- Replaced `gdal`/`osgeo` dependencies with `rasterio` and `geopandas` (#38).
+- Ported remaining standalone-script argparse parsers to click (#39).
+- Enabled autofixable Ruff rules and applied autofixes/formatting (#41).
+- Ruff formatting, lint fixes, and dead-code cleanup (#33).
+
+### Fixed
+- `icesat2_vertical_datum` config being silently ignored by globato (#35).
+
+### Removed
+- Validate-time landmask code (#34).
+- `archive` directory (#37).
+- Codacy workflow (#41).
+
+## [0.6.1] - 2026-07-10
+
+### Fixed
+- Incompatibility with Windows (#26).
+
+## [0.6.0] - 2026-07-10
+
+- First release with a tracked changelog.
+
+[0.6.6]: https://github.com/continuous-dems/ivert/compare/0.6.5...0.6.6
+[0.6.5]: https://github.com/continuous-dems/ivert/compare/0.6.4...0.6.5
+[0.6.4]: https://github.com/continuous-dems/ivert/compare/0.6.3...0.6.4
+[0.6.3]: https://github.com/continuous-dems/ivert/compare/0.6.2...0.6.3
+[0.6.2]: https://github.com/continuous-dems/ivert/compare/0.6.1...0.6.2
+[0.6.1]: https://github.com/continuous-dems/ivert/compare/0.6.0...0.6.1
+[0.6.0]: https://github.com/continuous-dems/ivert/releases/tag/0.6.0


### PR DESCRIPTION
Adds a `CHANGELOG.md` following the [Keep a Changelog](https://keepachangelog.com/) format, back-filled with entries for all 0.6.x releases (0.6.0 through 0.6.6).

- Entries are grouped Added/Changed/Fixed/Removed, newest first, with PR references.
- 0.6.6 covers the `ivert classes` (#55) and `ivert database export` (#56) commands plus README/docs updates (#57); dated 2026-07-20 as the pending re-release.
- Includes a link-reference section mapping each version to its GitHub compare/tag URL. The `0.6.6` compare link resolves once the tag is pushed.