### PR TITLE
Expand 'ivert database export' to accept .nc granule and index files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to IVERT are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `ivert database export` now accepts a single IVERT `.nc` photon granule (exported in its entirety) or the IVERT database index `.nc` file (exported as a polygon layer of per-granule `data_bbox` footprints), auto-detected from the file's contents (#59).
+
+### Changed
+- `ivert database export` now clips photons to the actual polygons of a polygon-vector region file, rather than only to that file's rectangular extent (#59).
+
 ## [0.6.6] - 2026-07-20
 
 ### Added

--- a/docs/database.md
+++ b/docs/database.md
@@ -95,7 +95,7 @@ Photon class codes:
 
 ## export
 
-Export photons from the database to common GIS vector formats. Each exported photon carries its full set of fields: `x`, `y`, `z`, `class_code`, `class_name`, `confidence`, `delta_time`, `granule_id`, and (where present) `bathy_confidence`.
+Export data from the database to common GIS vector formats. Each exported photon carries its full set of fields: `x`, `y`, `z`, `class_code`, `class_name`, `confidence`, `delta_time`, `granule_id`, and (where present) `bathy_confidence`.
 
 ```
 ivert database export [BBOX_OR_FILE] [OPTIONS]
@@ -103,7 +103,7 @@ ivert database export [BBOX_OR_FILE] [OPTIONS]
 
 ### Choosing what to export
 
-With no region argument, the **entire database** is exported. Optionally restrict the export to one geographic area — either a bounding box or a georeferenced file (a raster or a polygon-vector file) whose extent defines the region:
+The positional argument says what to export. With no argument, the **entire database** is exported.
 
 ```
 # Export the whole database (default output: ./ivert_photons.gpkg)
@@ -115,22 +115,37 @@ ivert database export -- -74.0/-73.0/40.5/41.0
 # Use --wsen if your numbers are in W/S/E/N order
 ivert database export --wsen -- -74.0/40.5/-73.0/41.0
 
-# Use the extent of a raster or polygon-vector file
+# Use the extent of a georeferenced raster
 ivert database export mydem.tif
+
+# Export only the photons inside the polygon(s) of a vector file
 ivert database export coastline.gpkg
+
+# Export one IVERT photon granule in its entirety
+ivert database export ~/.ivert/database/granules/ATL24_20230419_x-74.00y40.50.nc
+
+# Export the database index as polygon footprints, one per granule
+ivert database export ~/.ivert/database/granules/_ivert_database_index.nc
 ```
 
-> **Note:** Because the region argument is variable-length, put any options *before* a `--` delimiter when the bounding box begins with a negative number (e.g. `ivert database export -c 40/41 -- -74.0/-73.0/40.5/41.0`).
+A **polygon-vector file** (`.shp`, `.gpkg`, `.geojson`, `.gml`, `.kml`) defines the area — or set of areas — to export: photons are clipped to the polygons themselves, not just to their combined rectangular extent, so disjoint polygons export only the data inside each one. Files with no polygonal geometry fall back to their bounding-box extent.
+
+A **`.nc` file** is exported directly off disk, with no database lookup, and IVERT detects which kind it is from the file's contents:
+
+- an **IVERT photon granule** exports in its entirety, as a point layer. This is the way to pull one specific granule out of the database — and, looping over the granule files, to export the whole database one granule at a time. The `--classes` and date options still apply.
+- the **IVERT database index** (`_ivert_database_index.nc`) exports as a *polygon* layer: one rectangle per granule, drawn from its `data_bbox`, carrying every index field. Because it holds polygons rather than points, it cannot be exported as `xyz`, and the photon filters (`--classes`, `--start-date`, `--end-date`) do not apply to it.
+
+> **Note:** Because the positional argument is variable-length, put any options *before* a `--` delimiter when the bounding box begins with a negative number (e.g. `ivert database export -c 40/41 -- -74.0/-73.0/40.5/41.0`).
 
 ### Output format options
 
 | Flag | Default | Description |
 |------|---------|-------------|
 | `-of, --output-format FORMATS` | `gpkg` | Vector format(s): `gpkg`, `shp`, `xyz`, or a comma-separated combination (e.g. `gpkg,shp`) |
-| `-o, --output PATH` | `./ivert_photons` | Output file path. The correct extension is added per format, so multiple formats share this base name |
+| `-o, --output PATH` | `./ivert_photons` | Output file path. The correct extension is added per format, so multiple formats share this base name. When exporting a single `.nc` file, the default is the input file's name (`./ivert_database_index` for the index) |
 | `-ow, --overwrite` | | Overwrite existing output files (otherwise formats whose file already exists are skipped) |
 
-Shapefiles (`shp`) drop the `class_name` and `granule_id` fields, which exceed the format's field-name/length limits; `gpkg` and `xyz` retain all fields.
+Shapefiles (`shp`) drop the `class_name` and `granule_id` photon fields, which exceed the format's field-name/length limits; `gpkg` and `xyz` retain all fields. Database-index exports to `shp` keep every field, under shortened names (e.g. `numphotons_bathy_floor` → `n_bathyflr`, `data_bbox_xmin` → `d_xmin`).
 
 ### Filtering options
 
@@ -139,6 +154,8 @@ Shapefiles (`shp`) drop the `class_name` and `granule_id` fields, which exceed t
 | `-c, --classes TEXT` | all classes | Slash-separated photon class codes to include (e.g. `40/41`). See [class codes](#photon-class-options) above, or run `ivert classes` |
 | `-ds, --start-date TEXT` | no lower bound | Only export photons on or after this date. Accepts dateparser formats: `2023-01-01`, `"1 year ago"`, `20230101` |
 | `-de, --end-date TEXT` | no upper bound | Only export photons before this date |
+
+These filter individual photons, so they apply to every export except the database index, where they are ignored (with a note printed).
 
 ### Other options
 
@@ -244,4 +261,15 @@ ivert database export -of gpkg,shp -c 40/41 -o bahamas_bathy -- -78.5/-77.0/24.0
 **Export the whole database (all photons) to an XYZ text file:**
 ```
 ivert database export -of xyz -o all_photons
+```
+
+**Export the photons inside a set of polygons:**
+```
+ivert database export study_areas.gpkg -o study_area_photons
+```
+
+**Export one granule, and the database index as granule footprints:**
+```
+ivert database export ~/.ivert/database/granules/ATL24_20230419_x-74.00y40.50.nc
+ivert database export ~/.ivert/database/granules/_ivert_database_index.nc -of gpkg,shp
 ```

--- a/src/ivert/cli.py
+++ b/src/ivert/cli.py
@@ -8,6 +8,7 @@ Command-line interface for the ICESat-2 Validation of Elevations Reporting Tool 
 import glob
 import logging
 import os
+import typing
 from pathlib import Path
 
 # Set NUMEXPR_MAX_THREADS before any import loads NumExpr, to suppress the
@@ -986,33 +987,66 @@ _EXPORT_REGION_VECTOR_EXTENSIONS = (
 )
 
 
-def _wgs84_bbox_from_file(path):
-    """Return a WGS84 (xmin, xmax, ymin, ymax) bbox from a raster or polygon-vector file."""
+class _ExportTarget(typing.NamedTuple):
+    """What the positional argument of 'ivert database export' resolved to.
+
+    kind is "all" (the whole database), "region" (a bounding box and/or a set of
+    polygons), "granule" (one IVERT .nc photon granule file), or "index" (the
+    IVERT database index .nc file).
+    """
+
+    kind: str
+    # WGS84 (xmin, xmax, ymin, ymax), or None.
+    bbox: tuple | None
+    # A shapely (Multi)Polygon in WGS84 to clip photons to, or None.
+    geometry: object | None
+    # The input file, for the "granule" and "index" kinds.
+    path: str | None
+
+
+def _region_from_vector_file(path):
+    """Return (bbox, geometry) for a polygon-vector file defining an export region.
+
+    The bbox is the file's WGS84 total extent; the geometry is the union of the
+    file's polygons (None if the file holds no polygonal geometry, in which case
+    the extent alone defines the region).
+    """
+    import geopandas
+
+    gdf = geopandas.read_file(path)
+    if gdf.crs is not None and gdf.crs.to_epsg() != 4326:
+        gdf = gdf.to_crs(epsg=4326)
+
+    minx, miny, maxx, maxy = (float(v) for v in gdf.total_bounds)
+    bbox = (minx, maxx, miny, maxy)
+
+    polygons = gdf[gdf.geom_type.isin(("Polygon", "MultiPolygon"))]
+    geometry = polygons.geometry.union_all() if len(polygons) > 0 else None
+    return bbox, geometry
+
+
+def _region_from_file(path):
+    """Return (bbox, geometry) for a raster or polygon-vector file."""
     ext = os.path.splitext(path)[1].lower()
     if ext in _EXPORT_REGION_VECTOR_EXTENSIONS:
-        import geopandas
-
-        gdf = geopandas.read_file(path)
-        if gdf.crs is not None and gdf.crs.to_epsg() != 4326:
-            gdf = gdf.to_crs(epsg=4326)
-        minx, miny, maxx, maxy = (float(v) for v in gdf.total_bounds)
-        return (minx, maxx, miny, maxy)
+        return _region_from_vector_file(path)
 
     # Otherwise treat it as a raster; the CRS is read from the file header.
     from ivert.utils import dem_geom
 
-    return dem_geom.get_wgs84_bounding_box(path)
+    return dem_geom.get_wgs84_bounding_box(path), None
 
 
-def _region_to_wgs84_bbox(tokens, projection, wsen):
-    """Parse export-region tokens into a WGS84 (xmin, xmax, ymin, ymax) bbox.
+def _resolve_export_target(tokens, projection, wsen):
+    """Resolve the positional argument of 'ivert database export' to an _ExportTarget.
 
-    Returns None when no tokens are given (i.e. export the entire database).
-    Tokens are either a 4-value slash-separated bounding box or a single path to
-    a georeferenced raster or polygon-vector file.
+    Tokens are one of: nothing (export the entire database), a 4-value
+    slash-separated bounding box, or a single path to an IVERT .nc file (a photon
+    granule or the database index, auto-detected by content) or to a georeferenced
+    raster or polygon-vector file whose area defines the region to export.
     """
     if not tokens:
-        return None
+        return _ExportTarget("all", None, None, None)
 
     # Flatten slash-separated tokens into a flat list of values.
     values = []
@@ -1035,33 +1069,125 @@ def _region_to_wgs84_bbox(tokens, projection, wsen):
                 xmin, xmax, ymin, ymax = nums
 
             if projection.upper() in ("EPSG:4326", "4326"):
-                return (xmin, xmax, ymin, ymax)
+                bbox = (xmin, xmax, ymin, ymax)
+            else:
+                from ivert.utils import dem_geom
 
-            from ivert.utils import dem_geom
+                bbox = dem_geom.get_wgs84_bounding_box(
+                    (xmin, xmax, ymin, ymax),
+                    dem_horz_reference_frame=projection,
+                )
 
-            return dem_geom.get_wgs84_bounding_box(
-                (xmin, xmax, ymin, ymax),
-                dem_horz_reference_frame=projection,
-            )
+            return _ExportTarget("region", bbox, None, None)
 
-    # Otherwise the region must be a single georeferenced file.
+    # Otherwise the argument must be a single file.
     if len(tokens) != 1:
         raise click.ClickException(
-            "Region must be a 4-value bounding box or a single georeferenced file.",
+            "Region must be a 4-value bounding box or a single file.",
         )
 
     path = tokens[0]
     if not os.path.exists(path):
         raise click.ClickException(
-            f"Region '{path}' is neither a valid 4-value bounding box nor an existing file.",
+            f"'{path}' is neither a valid 4-value bounding box nor an existing file.",
+        )
+
+    # An IVERT .nc file is exported directly; which kind it is comes from its contents.
+    if os.path.splitext(path)[1].lower() == ".nc":
+        from ivert import export_vector as ev
+
+        kind = ev.detect_nc_kind(path)
+        if kind == ev.KIND_INDEX:
+            return _ExportTarget("index", None, None, path)
+        if kind == ev.KIND_PHOTONS:
+            return _ExportTarget("granule", None, None, path)
+        raise click.ClickException(
+            f"'{path}' is not an IVERT photon granule or database index file.",
         )
 
     try:
-        return _wgs84_bbox_from_file(path)
+        bbox, geometry = _region_from_file(path)
     except Exception as exc:
         raise click.ClickException(
-            f"Could not read a bounding box from '{path}': {exc}",
+            f"Could not read an export region from '{path}': {exc}",
         ) from exc
+
+    return _ExportTarget("region", bbox, geometry, None)
+
+
+def _echo_export_summary(written, count, noun):
+    """Report the files an export wrote (or that it wrote none)."""
+    if not written:
+        click.echo(
+            "\nNo files written (all target files already exist; use -ow to overwrite).",
+        )
+        return
+
+    click.echo(f"\nExported {count:,} {noun} to {len(written)} file(s):")
+    for path in written:
+        click.echo(f"  {path}")
+
+
+def _export_database_index(index_path, fmt_keys, output, overwrite, filters_given):
+    """Export an IVERT database index file as a polygon layer of granule footprints."""
+    from ivert import export_vector as ev
+
+    point_formats = [key for key in fmt_keys if key in ("xyz", "csv")]
+    if point_formats:
+        raise click.ClickException(
+            "The database index holds bounding-box polygons rather than points, so it "
+            f"cannot be exported as '{', '.join(point_formats)}'. Use 'gpkg' and/or "
+            "'shp' instead.",
+        )
+
+    if filters_given:
+        click.echo(
+            "Note: the --classes and date options filter photons, so they do not apply "
+            "to a database-index export. Exporting the whole index.",
+            err=True,
+        )
+
+    gdf = ev.index_to_geodataframe(index_path)
+    if len(gdf) == 0:
+        raise click.ClickException(f"The database index is empty: {index_path}")
+
+    out_base = output or os.path.join(os.getcwd(), "ivert_database_index")
+    written = ev.write_vector_multi(
+        gdf,
+        out_base,
+        fmt_keys,
+        overwrite=overwrite,
+        kind=ev.KIND_INDEX,
+    )
+    _echo_export_summary(written, len(gdf), "granule footprints")
+
+
+def _export_single_granule(
+    nc_path,
+    fmt_keys,
+    output,
+    overwrite,
+    class_list,
+    delta_time_range,
+):
+    """Export one IVERT .nc photon granule file in its entirety."""
+    from ivert import export_vector as ev
+
+    gdf = ev.nc_to_geodataframe(nc_path, classes=class_list)
+    if delta_time_range is not None:
+        gdf = ev.subset_gdf_to_date_range(gdf, *delta_time_range)
+
+    if len(gdf) == 0:
+        raise click.ClickException(
+            f"No photons left to export from {os.path.basename(nc_path)} after filtering.",
+        )
+
+    out_base = output or os.path.join(
+        os.getcwd(),
+        os.path.splitext(os.path.basename(nc_path))[0],
+    )
+    written = ev.write_vector_multi(gdf, out_base, fmt_keys, overwrite=overwrite)
+    _echo_export_summary(written, len(gdf), "photons")
 
 
 @database.command("export")
@@ -1086,7 +1212,8 @@ def _region_to_wgs84_bbox(tokens, projection, wsen):
     metavar="PATH",
     help=(
         "Output file path. The correct extension is added per format, so multiple "
-        "formats share this base name. Default: 'ivert_photons' in the current directory."
+        "formats share this base name. Default: 'ivert_photons' in the current "
+        "directory, or the input file's name when exporting a single .nc file."
     ),
 )
 @click.option(
@@ -1169,14 +1296,25 @@ def database_export(
 ):
     """Export IVERT ICESat-2 photons to GIS vector formats.
 
-    BBOX_OR_FILE (optional) restricts the export to one geographic area: either a
-    4-value bounding box in W/E/S/N order (slash-separated, e.g. -74/-73/40.5/41),
-    or a path to a georeferenced raster or polygon-vector file whose extent defines
-    the region. With no region given, the entire database is exported.
+    BBOX_OR_FILE (optional) says what to export. It is one of:
 
-    Each output carries the same per-photon fields as 'ivert database' stores
+    \b
+      * nothing — export every photon in the database
+      * a 4-value bounding box in W/E/S/N order (slash-separated,
+        e.g. -74/-73/40.5/41)
+      * a georeferenced raster file, whose extent defines the region
+      * a polygon-vector file, whose polygon(s) define the area(s) to export
+      * a single IVERT .nc photon granule, exported in its entirety
+      * the IVERT database index .nc file, exported as a polygon layer of
+        granule footprints (one rectangle per granule, from its data_bbox)
+
+    The last two are auto-detected from the contents of the .nc file.
+
+    Photon outputs carry the same per-photon fields as 'ivert database' stores
     (x, y, z, class_code, class_name, confidence, delta_time, granule_id, and
-    bathy_confidence where present).
+    bathy_confidence where present). The database index exports every field it
+    holds per granule, and cannot be written as 'xyz' since it holds polygons
+    rather than points.
 
     Examples:
         ivert database export
@@ -1186,6 +1324,10 @@ def database_export(
         ivert database export -- -74/-73/40.5/41 -c 40/41 -ds 2023.01.01 -de 2024.01.01
 
         ivert database export coastline.gpkg -of xyz
+
+        ivert database export granules/ATL24_20230101_x-74y40.nc
+
+        ivert database export granules/_ivert_database_index.nc -of gpkg,shp
 
     (Note: Use the '--' delimiter to end command-line options if coordinates begin
     with a negative '-')
@@ -1215,17 +1357,11 @@ def database_export(
                 f"Invalid --classes value '{classes}': {exc}",
             ) from exc
 
-    # --- Parse region. ---
-    bbox = _region_to_wgs84_bbox(list(bbox_or_file), projection, wsen)
+    # --- Work out what was asked for. ---
+    target = _resolve_export_target(list(bbox_or_file), projection, wsen)
+    bbox = target.bbox
 
-    # --- Open the database index. ---
     db = is2db_mod.IS2Database()
-    gdf_index = db.open_gdf(verbose=False)
-    if gdf_index is None or len(gdf_index) == 0:
-        raise click.ClickException(
-            f"No IVERT database found (or it is empty) at: {db.db_fname}\n"
-            "Run 'ivert database download <bbox>' to create one.",
-        )
 
     # --- Parse the optional date range. ---
     date_filtering = date_start is not None or date_end is not None
@@ -1242,6 +1378,40 @@ def database_export(
             raise click.ClickException(
                 f"--start-date ({tmin}) must be before --end-date ({tmax}).",
             )
+
+    # --- A single .nc file is read straight off disk, with no database lookup. ---
+    if target.kind == "index":
+        _export_database_index(
+            target.path,
+            fmt_keys,
+            output,
+            overwrite,
+            filters_given=bool(classes) or date_filtering,
+        )
+        return
+
+    if target.kind == "granule":
+        _export_single_granule(
+            target.path,
+            fmt_keys,
+            output,
+            overwrite,
+            class_list,
+            (
+                (_yyyymmdd_to_delta_time(tmin), _yyyymmdd_to_delta_time(tmax))
+                if date_filtering
+                else None
+            ),
+        )
+        return
+
+    # --- Open the database index. ---
+    gdf_index = db.open_gdf(verbose=False)
+    if gdf_index is None or len(gdf_index) == 0:
+        raise click.ClickException(
+            f"No IVERT database found (or it is empty) at: {db.db_fname}\n"
+            "Run 'ivert database download <bbox>' to create one.",
+        )
 
     # --- Select the granules to read. ---
     if bbox is None and not date_filtering:
@@ -1286,7 +1456,6 @@ def database_export(
     click.echo(f"Reading {total:,} granule(s) ...")
 
     gdfs = []
-    photon_count = 0
     for i, (_, row) in enumerate(granule_rows.iterrows(), start=1):
         fpath = os.path.join(db.granules_dir, row["filename"])
         if not os.path.exists(fpath):
@@ -1296,12 +1465,13 @@ def database_export(
         gdf = ev.nc_to_geodataframe(fpath, classes=class_list)
         if bbox is not None:
             gdf = ev.subset_gdf_to_bbox(gdf, bbox)
+        if target.geometry is not None:
+            gdf = ev.subset_gdf_to_geometry(gdf, target.geometry)
         if date_filtering:
             gdf = ev.subset_gdf_to_date_range(gdf, dt_min, dt_max)
 
         if len(gdf) > 0:
             gdfs.append(gdf)
-            photon_count += len(gdf)
 
         if verbose:
             click.echo(f"  [{i}/{total}] {row['filename']}: {len(gdf):,} photons")
@@ -1317,16 +1487,7 @@ def database_export(
     # --- Write the requested format(s). ---
     out_base = output or os.path.join(os.getcwd(), "ivert_photons")
     written = ev.write_vector_multi(merged, out_base, fmt_keys, overwrite=overwrite)
-
-    if not written:
-        click.echo(
-            "\nNo files written (all target files already exist; use -ow to overwrite).",
-        )
-        return
-
-    click.echo(f"\nExported {len(merged):,} photons to {len(written)} file(s):")
-    for path in written:
-        click.echo(f"  {path}")
+    _echo_export_summary(written, len(merged), "photons")
 
 
 ###############################################################

--- a/src/ivert/export_vector.py
+++ b/src/ivert/export_vector.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
-"""export_vector — convert IVERT ICESat-2 .nc granule files to GIS vector formats.
+"""export_vector — convert IVERT NetCDF files to GIS vector formats.
 
-Reads .nc files produced by IS2Database._process_h5_to_nc() and writes them as
-geolocated point vector files (GeoPackage, Shapefile, or CSV/XYZ).
+Reads the .nc files produced by IS2Database._process_h5_to_nc() and writes them
+as geolocated point vector files (GeoPackage, Shapefile, or CSV/XYZ), and reads
+the IVERT database index .nc file and writes it as a polygon vector file, one
+rectangular data_bbox footprint per granule.
 
 This module is the library backing the 'ivert database export' command; it has
 no command-line interface of its own.
@@ -26,6 +28,71 @@ SUPPORTED_FORMATS = {
 }
 
 WGS84_EPSG = 4326
+
+# The two kinds of IVERT .nc file this module can export. Photon granules become
+# point layers; the database index becomes a polygon layer.
+KIND_PHOTONS = "photons"
+KIND_INDEX = "index"
+
+# Variables that identify each kind of .nc file (see detect_nc_kind()).
+_GRANULE_SIGNATURE_VARS = ("x", "y", "z", "class_code")
+_INDEX_SIGNATURE_VARS = ("filename", "granule_id", "data_bbox_xmin", "data_bbox_ymax")
+
+# Shapefiles cap field names at 10 characters and silently truncate longer ones
+# into collisions, so the index columns get explicit short aliases instead.
+_INDEX_SHAPEFILE_ALIASES = {
+    "source_granule": "src_gran",
+    "horizontal_datum": "horiz_dtm",
+    "vertical_datum": "vert_dtm",
+    "query_bbox_xmin": "q_xmin",
+    "query_bbox_xmax": "q_xmax",
+    "query_bbox_ymin": "q_ymin",
+    "query_bbox_ymax": "q_ymax",
+    "query_bbox_tmin": "q_tmin",
+    "query_bbox_tmax": "q_tmax",
+    "data_bbox_xmin": "d_xmin",
+    "data_bbox_xmax": "d_xmax",
+    "data_bbox_ymin": "d_ymin",
+    "data_bbox_ymax": "d_ymax",
+    "data_bbox_tmin": "d_tmin",
+    "data_bbox_tmax": "d_tmax",
+    "zbounds_zmin": "zmin",
+    "zbounds_zmax": "zmax",
+    "numphotons_unclassified": "n_unclass",
+    "numphotons_noise": "n_noise",
+    "numphotons_ground": "n_ground",
+    "numphotons_canopy": "n_canopy",
+    "numphotons_canopy_top": "n_canoptop",
+    "numphotons_ice_surface": "n_ice",
+    "numphotons_bathy_floor": "n_bathyflr",
+    "numphotons_bathy_surface": "n_bathysrf",
+    "numphotons_buildings": "n_bldg",
+    "numphotons_inland_water_surface": "n_inlwater",
+    "downloaded_on": "dnld_on",
+}
+
+
+# ---------------------------------------------------------------------------
+# File-kind detection
+# ---------------------------------------------------------------------------
+def detect_nc_kind(nc_path: str) -> str | None:
+    """Identify what kind of IVERT NetCDF file this is.
+
+    Returns KIND_INDEX for the database index file, KIND_PHOTONS for a photon
+    granule file, or None if the file is a NetCDF file of neither kind (or isn't
+    readable as NetCDF at all).
+    """
+    try:
+        with netCDF4.Dataset(nc_path) as ds:
+            names = set(ds.variables)
+    except OSError:
+        return None
+
+    if all(v in names for v in _INDEX_SIGNATURE_VARS):
+        return KIND_INDEX
+    if all(v in names for v in _GRANULE_SIGNATURE_VARS):
+        return KIND_PHOTONS
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -99,13 +166,62 @@ def nc_to_geodataframe(nc_path: str, classes: list = None) -> geopandas.GeoDataF
     return gdf
 
 
+def index_to_geodataframe(index_path: str) -> geopandas.GeoDataFrame:
+    """Read an IVERT database index .nc file and return a polygon GeoDataFrame.
+
+    Each row is one granule in the index, carrying every index field, with its
+    data_bbox drawn as a rectangular polygon for the geometry.
+    """
+    import shapely.geometry
+
+    from ivert.icesat2_database_v2 import IS2Database
+
+    df = IS2Database.read_index_file(index_path)
+
+    if len(df) == 0:
+        return geopandas.GeoDataFrame(df, geometry=[], crs=WGS84_EPSG)
+
+    geometry = [
+        shapely.geometry.box(xmin, ymin, xmax, ymax)
+        for xmin, xmax, ymin, ymax in zip(
+            df["data_bbox_xmin"],
+            df["data_bbox_xmax"],
+            df["data_bbox_ymin"],
+            df["data_bbox_ymax"],
+            strict=True,
+        )
+    ]
+    return geopandas.GeoDataFrame(df, geometry=geometry, crs=WGS84_EPSG)
+
+
+def _prepare_for_shapefile(
+    gdf: geopandas.GeoDataFrame,
+    kind: str,
+) -> geopandas.GeoDataFrame:
+    """Return a copy of a GeoDataFrame whose fields fit the shapefile format.
+
+    Shapefiles cap field names at 10 characters. Index fields are renamed to
+    short aliases; photon fields that carry no per-point information worth the
+    truncation (class_name, granule_id) are dropped.
+    """
+    if kind == KIND_INDEX:
+        return gdf.rename(columns=_INDEX_SHAPEFILE_ALIASES)
+    return gdf.drop(columns=["class_name", "granule_id"], errors="ignore")
+
+
 def write_vector(
     gdf: geopandas.GeoDataFrame,
     outpath: str,
     fmt_key: str,
     overwrite: bool = False,
+    kind: str = KIND_PHOTONS,
 ):
-    """Write a GeoDataFrame to the requested vector format."""
+    """Write a GeoDataFrame to the requested vector format.
+
+    kind is KIND_PHOTONS for a point layer of photons or KIND_INDEX for a
+    polygon layer of granule footprints; it governs the shapefile field
+    handling and the wording of the progress message.
+    """
     if os.path.exists(outpath):
         if not overwrite:
             print(
@@ -120,14 +236,12 @@ def write_vector(
         out_df = gdf.drop(columns="geometry")
         out_df.to_csv(outpath, index=False)
     else:
-        # Shapefiles truncate field names to 10 chars and don't support
-        # string columns well — drop granule_id if it would be truncated badly.
         if fmt_key == "shp":
-            gdf = gdf.copy()
-            gdf = gdf.drop(columns=["class_name", "granule_id"], errors="ignore")
+            gdf = _prepare_for_shapefile(gdf.copy(), kind)
         gdf.to_file(outpath, driver=driver)
 
-    print(f"  → {outpath}  ({len(gdf):,} photons)")
+    noun = "granules" if kind == KIND_INDEX else "photons"
+    print(f"  → {outpath}  ({len(gdf):,} {noun})")
 
 
 # ---------------------------------------------------------------------------
@@ -190,6 +304,27 @@ def subset_gdf_to_bbox(gdf: geopandas.GeoDataFrame, bbox) -> geopandas.GeoDataFr
     return gdf[mask].reset_index(drop=True)
 
 
+def subset_gdf_to_geometry(
+    gdf: geopandas.GeoDataFrame,
+    geometry,
+) -> geopandas.GeoDataFrame:
+    """Return the subset of a photon GeoDataFrame falling inside a polygon geometry.
+
+    geometry is a single shapely (Multi)Polygon in the GeoDataFrame's own CRS,
+    typically the union of every polygon in a user-supplied vector file. The
+    geometry is prepared once and tested against all points in one vectorized
+    call, so this stays fast for millions of photons.
+    """
+    if gdf.empty or geometry is None:
+        return gdf
+
+    import shapely
+
+    shapely.prepare(geometry)
+    mask = shapely.intersects(geometry, gdf.geometry.values)
+    return gdf[mask].reset_index(drop=True)
+
+
 def subset_gdf_to_date_range(
     gdf: geopandas.GeoDataFrame,
     dt_min: float,
@@ -227,6 +362,7 @@ def write_vector_multi(
     out_base: str,
     fmt_keys,
     overwrite: bool = False,
+    kind: str = KIND_PHOTONS,
 ) -> list:
     """Write a GeoDataFrame to one or more vector formats.
 
@@ -236,7 +372,7 @@ def write_vector_multi(
     for fmt_key in fmt_keys:
         outpath = output_path_for_format(out_base, fmt_key)
         existed = os.path.exists(outpath)
-        write_vector(gdf, outpath, fmt_key, overwrite=overwrite)
+        write_vector(gdf, outpath, fmt_key, overwrite=overwrite, kind=kind)
         # write_vector() skips silently when the file exists and overwrite is False.
         if not existed or overwrite:
             written.append(outpath)

--- a/src/ivert/icesat2_database_v2.py
+++ b/src/ivert/icesat2_database_v2.py
@@ -665,34 +665,43 @@ class IS2Database:
         )
         ds.to_netcdf(self.db_fname, encoding=encoding)
 
-    def _read_index(self):
-        """Read the NetCDF index file back into a plain pandas DataFrame.
+    @classmethod
+    def read_index_file(cls, index_fname: str) -> pandas.DataFrame:
+        """Read any IVERT NetCDF index file into a plain pandas DataFrame.
 
-        Returns None if the index file does not exist. Every column comes back as
-        a numpy array with no per-row Python loops and no geometry reconstruction,
-        which is what makes this read fast; spatial filtering is done downstream
-        with vectorized bbox comparisons on the data_bbox_* / query_bbox_* columns.
+        Every column comes back as a numpy array with no per-row Python loops and
+        no geometry reconstruction, which is what makes this read fast; spatial
+        filtering is done downstream with vectorized bbox comparisons on the
+        data_bbox_* / query_bbox_* columns. Columns are in the canonical order
+        given by _empty_db_dict().
         """
-        if not os.path.exists(self.db_fname):
-            return None
-
-        with xarray.open_dataset(self.db_fname) as ds:
+        with xarray.open_dataset(index_fname) as ds:
             ds = ds.load()
 
         data = {}
-        for col in self._INDEX_STR_COLS:
+        for col in cls._INDEX_STR_COLS:
             data[col] = ds[col].values.astype(str)
         for col in (
-            *self._INDEX_INT_COLS,
-            *self._INDEX_BBOX_INT_COLS,
-            *self._INDEX_BBOX_FLOAT_COLS,
-            *self._INDEX_ZBOUNDS_COLS,
+            *cls._INDEX_INT_COLS,
+            *cls._INDEX_BBOX_INT_COLS,
+            *cls._INDEX_BBOX_FLOAT_COLS,
+            *cls._INDEX_ZBOUNDS_COLS,
         ):
             data[col] = ds[col].values
 
         df = pandas.DataFrame(data)
         # Restore the canonical column order used elsewhere in the codebase.
-        return df[list(self._empty_db_dict().keys())]
+        return df[list(cls._empty_db_dict().keys())]
+
+    def _read_index(self):
+        """Read this database's index file back into a plain pandas DataFrame.
+
+        Returns None if the index file does not exist.
+        """
+        if not os.path.exists(self.db_fname):
+            return None
+
+        return self.read_index_file(self.db_fname)
 
     def open_gdf(
         self,


### PR DESCRIPTION
Closes #59.

Expands the positional argument of `ivert database export` beyond bounding boxes and raster/vector extents. It now accepts:

- **A single IVERT `.nc` photon granule** — exported in its entirety, as a point layer. This pulls one specific granule out of the database, and (looping over the granule files) supports exporting the whole database one granule at a time. `--classes` and the date options still apply.
- **The IVERT database index `.nc` file** — exported as a *polygon* layer: one rectangle per granule, drawn from its `data_bbox`, carrying every index field. Since it holds polygons rather than points it cannot be written as `xyz`, and the photon filters do not apply to it (a note is printed if they are given).

Both are auto-detected from the file's variables (`filename`/`granule_id`/`data_bbox_*` for the index, `x`/`y`/`z`/`class_code` for a granule), and both are read straight off disk with no database lookup, so neither requires a populated local database. A `.nc` file of neither kind gives a clear error.

### Also in this PR

- **Polygon-vector region files now clip to the polygons themselves**, not just to their combined rectangular extent, so a file of disjoint polygons exports only the data inside each one. The bounding box is still used to pre-select which granules to read, and the clip is a single vectorized `shapely.intersects` call against a prepared geometry. Files with no polygonal geometry fall back to their extent, as before. This is a behavior change for polygon inputs.
- **Index shapefile output uses explicit short field aliases** (`numphotons_bathy_floor` → `n_bathyflr`, `data_bbox_xmin` → `d_xmin`, …), so all 32 index fields survive the format's 10-character field-name cap instead of colliding under GDAL's truncation.
- `IS2Database._read_index()` split into a `read_index_file(path)` classmethod, so any index file can be read and not only the configured one.

The existing bounding-box and raster-extent behavior is unchanged.

### Testing

Verified against synthetic fixtures (a photon granule, a two-record index, and a two-polygon GeoPackage):

- whole-database, bounding-box, and raster-extent exports
- polygon clip: 292 of 500 photons exported, all inside the polygons, with the 158 photons in the gap between the two polygons correctly excluded
- polygon file combined with `--classes` and a date range
- granule export with and without `-o` (default output name derives from the input file)
- index export to `gpkg` and `shp`: polygon geometry, EPSG:4326, every field present with names within the shapefile limit
- error paths: missing file, non-IVERT `.nc`, non-NetCDF file named `.nc`, and `-of xyz` against the index

`prek run --all-files` passes. `pytest` is not installed in the dev env used here, so the test suite was not run.

Docs (`docs/database.md`) and `CHANGELOG.md` updated.