### PR TITLE
Enable eight previously-ignored ruff lint rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,6 @@ ignore = [
     "FBT002",   # boolean-default-value-positional-argument
     "FBT003",   # boolean-positional-value-in-call
     "FIX002",   # line-contains-todo
-    "FURB110",  # if-exp-instead-of-or-operator
     "ICN001",   # unconventional-import-alias
     "N801",     # invalid-class-name
     "N802",     # invalid-function-name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,6 @@ ignore = [
     "RET504",   # unnecessary-assign
     "RUF001",   # ambiguous-unicode-character-string
     "RUF002",   # ambiguous-unicode-character-docstring
-    "RUF005",   # collection-literal-concatenation
     "RUF012",   # mutable-class-default
     "RUF013",   # implicit-optional
     "RUF015",   # unnecessary-iterable-allocation-for-first-element

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,7 +156,6 @@ ignore = [
     "S603",     # subprocess-without-shell-equals-true
     "S605",     # start-process-with-a-shell
     "S607",     # start-process-with-partial-path
-    "SIM101",   # duplicate-isinstance-call
     "SIM102",   # collapsible-if
     "SIM105",   # suppressible-exception
     "SIM115",   # open-file-with-context-handler

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,6 @@ ignore = [
     "EM101",    # raw-string-in-exception
     "EM102",    # f-string-in-exception
     "ERA001",   # commented-out-code
-    "EXE001",   # shebang-not-executable
     "FBT001",   # boolean-type-hint-positional-argument
     "FBT002",   # boolean-default-value-positional-argument
     "FBT003",   # boolean-positional-value-in-call

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,6 +166,5 @@ ignore = [
     "TRY003",   # raise-vanilla-args
     "TRY004",   # type-check-without-type-error
     "TRY300",   # try-consider-else
-    "UP030",    # format-literals
     "UP031",    # printf-string-formatting
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,6 @@ ignore = [
     "PTH208",   # os-listdir
     "RET503",   # implicit-return
     "RET504",   # unnecessary-assign
-    "RSE102",   # unnecessary-paren-on-raise-exception
     "RUF001",   # ambiguous-unicode-character-string
     "RUF002",   # ambiguous-unicode-character-docstring
     "RUF005",   # collection-literal-concatenation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,6 @@ ignore = [
     "C401",     # unnecessary-generator-set
     "C403",     # unnecessary-list-comprehension-set
     "C404",     # unnecessary-list-comprehension-dict
-    "C408",     # unnecessary-collection-call
     "C414",     # unnecessary-double-cast-or-process
     "C901",     # complex-structure
     "D100",     # undocumented-public-module
@@ -170,7 +169,6 @@ ignore = [
     "TD003",    # missing-todo-link
     "TRY003",   # raise-vanilla-args
     "TRY004",   # type-check-without-type-error
-    "TRY201",   # verbose-raise
     "TRY300",   # try-consider-else
     "UP030",    # format-literals
     "UP031",    # printf-string-formatting

--- a/src/ivert/cli.py
+++ b/src/ivert/cli.py
@@ -944,7 +944,7 @@ def database_download(
             "\nContinue with the download anyway?",
             default=False,
         ):
-            raise click.Abort()
+            raise click.Abort
 
     class_list = tuple(int(c) for c in classes.split("/"))
 
@@ -1443,7 +1443,7 @@ def database_export(
             err=True,
         )
         if not click.confirm("\nContinue with the export anyway?", default=False):
-            raise click.Abort()
+            raise click.Abort
 
     # --- Read, subset, and merge granules. ---
     import geopandas

--- a/src/ivert/cli.py
+++ b/src/ivert/cli.py
@@ -570,7 +570,7 @@ def database_list(show_all, boxes):
         unique_boxes = sorted(
             {tuple(r) for r in gdf[qcols].itertuples(index=False)},
         )
-        rows = [b[:4] + (_fmt_date(b[4]), _fmt_date(b[5])) for b in unique_boxes]
+        rows = [(*b[:4], _fmt_date(b[4]), _fmt_date(b[5])) for b in unique_boxes]
         headers = ["Xmin", "Xmax", "Ymin", "Ymax", "Date Start", "Date End"]
         click.echo(tabulate_mod.tabulate(rows, headers=headers, tablefmt="simple"))
         click.echo(f"\n{len(unique_boxes)} unique query box(es)  —  db: {db.db_fname}")
@@ -1724,7 +1724,7 @@ def _run_validate(
 
     classes = [1, 6, 40]
     if buildings:
-        classes = sorted(classes + [7])
+        classes = sorted([*classes, 7])
 
     if len(expanded) == 1 and os.path.isfile(expanded[0]):
         # validate_dem uses output_dir as-is, so resolve any relative path against

--- a/src/ivert/cli.py
+++ b/src/ivert/cli.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """ivert.cli
 ~~~~~~~~~
 Command-line interface for the ICESat-2 Validation of Elevations Reporting Tool (IVERT).

--- a/src/ivert/cli.py
+++ b/src/ivert/cli.py
@@ -1736,21 +1736,21 @@ def _run_validate(
             )
         else:
             single_outdir = outdir
-        kwargs = dict(
-            dem_name=expanded[0],
-            output_dir=single_outdir,
-            classes=classes,
-            band_num=band_num,
-            outliers_sd_threshold=outlier_sd_threshold,
-            include_photon_level_validation=include_photons,
-            location_name=region_name,
-            measure_coverage=measure_coverage,
-            min_coverage_pct=minimum_coverage_pct,
-            min_confidence_level=confidence_level,
-            min_bathy_confidence=bathy_confidence,
-            verbose=verbose,
-            overwrite=overwrite,
-        )
+        kwargs = {
+            "dem_name": expanded[0],
+            "output_dir": single_outdir,
+            "classes": classes,
+            "band_num": band_num,
+            "outliers_sd_threshold": outlier_sd_threshold,
+            "include_photon_level_validation": include_photons,
+            "location_name": region_name,
+            "measure_coverage": measure_coverage,
+            "min_coverage_pct": minimum_coverage_pct,
+            "min_confidence_level": confidence_level,
+            "min_bathy_confidence": bathy_confidence,
+            "verbose": verbose,
+            "overwrite": overwrite,
+        }
         if vdatum != "NONE_PROVIDED":
             kwargs["dem_vertical_datum"] = vdatum
         if ndv_float is not None:
@@ -1772,21 +1772,21 @@ def _run_validate(
             multi_outdir = os.path.join(dem_dir, outdir)
         else:
             multi_outdir = outdir
-        kwargs = dict(
-            dem_list_or_dir=dem_input,
-            output_dir=multi_outdir,
-            classes=classes,
-            band_num=band_num,
-            place_name=region_name,
-            include_photon_validation=include_photons,
-            measure_coverage=measure_coverage,
-            min_coverage_pct=minimum_coverage_pct,
-            outliers_sd_threshold=outlier_sd_threshold,
-            min_confidence_level=confidence_level,
-            min_bathy_confidence=bathy_confidence,
-            verbose=verbose,
-            overwrite=overwrite,
-        )
+        kwargs = {
+            "dem_list_or_dir": dem_input,
+            "output_dir": multi_outdir,
+            "classes": classes,
+            "band_num": band_num,
+            "place_name": region_name,
+            "include_photon_validation": include_photons,
+            "measure_coverage": measure_coverage,
+            "min_coverage_pct": minimum_coverage_pct,
+            "outliers_sd_threshold": outlier_sd_threshold,
+            "min_confidence_level": confidence_level,
+            "min_bathy_confidence": bathy_confidence,
+            "verbose": verbose,
+            "overwrite": overwrite,
+        }
         if vdatum != "NONE_PROVIDED":
             kwargs["input_vdatum"] = vdatum
         if ndv_float is not None:

--- a/src/ivert/export_vector.py
+++ b/src/ivert/export_vector.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """export_vector — convert IVERT NetCDF files to GIS vector formats.
 
 Reads the .nc files produced by IS2Database._process_h5_to_nc() and writes them

--- a/src/ivert/icesat2_database_v2.py
+++ b/src/ivert/icesat2_database_v2.py
@@ -583,7 +583,7 @@ class IS2Database:
         xr_ds.attrs = metadata_attrs
 
         os.makedirs(
-            os.path.dirname(nc_fn) if os.path.dirname(nc_fn) else ".",
+            os.path.dirname(nc_fn) or ".",
             exist_ok=True,
         )
         xr_ds.to_netcdf(nc_fn)
@@ -660,7 +660,7 @@ class IS2Database:
                 encoding[col] = {"zlib": True, "complevel": 4}
 
         os.makedirs(
-            os.path.dirname(self.db_fname) if os.path.dirname(self.db_fname) else ".",
+            os.path.dirname(self.db_fname) or ".",
             exist_ok=True,
         )
         ds.to_netcdf(self.db_fname, encoding=encoding)

--- a/src/ivert/icesat2_database_v2.py
+++ b/src/ivert/icesat2_database_v2.py
@@ -1014,7 +1014,7 @@ class IS2Database:
             except ValueError:
                 # If it isn't a YYYYMMDD string, parse it with dateparser.
                 return int(dateparser.parse(date).strftime("%Y%m%d"))
-        elif isinstance(date, datetime.datetime) or isinstance(date, datetime.date):
+        elif isinstance(date, (datetime.datetime, datetime.date)):
             return int(date.strftime("%Y%m%d"))
         else:
             raise ValueError(

--- a/src/ivert/icesat2_requests.py
+++ b/src/ivert/icesat2_requests.py
@@ -174,10 +174,10 @@ class ICESat2RequestsCSV:
                 try:
                     self.df = pandas.read_csv(self.csv_file, index_col=False)
                     break
-                except (TypeError, pandas.errors.ParserError) as e:
+                except (TypeError, pandas.errors.ParserError):
                     num_tries += 1
                     if num_tries >= 20:
-                        raise e
+                        raise
                     time.sleep(0.001)
             self.df["bbox"] = self.df["bbox"].apply(ast.literal_eval)
         elif create_if_nonexistent:

--- a/src/ivert/photon_classes.py
+++ b/src/ivert/photon_classes.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """ivert.photon_classes
 ~~~~~~~~~~~~~~~~~~~~~~
 Single source of truth for ICESat-2 photon classification codes.

--- a/src/ivert/plot_photon_clouds_v2.py
+++ b/src/ivert/plot_photon_clouds_v2.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """plot_photon_clouds_v2.py — plot classified ICESat-2 photon curtains from .nc granule files.
 
 Usage

--- a/src/ivert/plot_photon_clouds_v2.py
+++ b/src/ivert/plot_photon_clouds_v2.py
@@ -35,16 +35,16 @@ from ivert.photon_classes import class_labels
 # Visual attributes only; legend labels come from ivert.photon_classes so they
 # stay in sync with the globato classifier.
 CLASS_STYLE = {
-    0: dict(color="grey", zorder=0.5, alpha=0.5, s=1),
-    1: dict(color="saddlebrown", zorder=2, alpha=1.0, s=3),
-    2: dict(color="limegreen", zorder=1, alpha=0.8, s=2),
-    3: dict(color="forestgreen", zorder=2, alpha=0.9, s=2),
-    7: dict(color="red", zorder=2, alpha=0.8, s=2),
-    40: dict(color="darkorange", zorder=3, alpha=1.0, s=3),
-    41: dict(color="dodgerblue", zorder=1, alpha=0.6, s=1),
-    42: dict(color="dodgerblue", zorder=1, alpha=0.6, s=1),
+    0: {"color": "grey", "zorder": 0.5, "alpha": 0.5, "s": 1},
+    1: {"color": "saddlebrown", "zorder": 2, "alpha": 1.0, "s": 3},
+    2: {"color": "limegreen", "zorder": 1, "alpha": 0.8, "s": 2},
+    3: {"color": "forestgreen", "zorder": 2, "alpha": 0.9, "s": 2},
+    7: {"color": "red", "zorder": 2, "alpha": 0.8, "s": 2},
+    40: {"color": "darkorange", "zorder": 3, "alpha": 1.0, "s": 3},
+    41: {"color": "dodgerblue", "zorder": 1, "alpha": 0.6, "s": 1},
+    42: {"color": "dodgerblue", "zorder": 1, "alpha": 0.6, "s": 1},
 }
-DEFAULT_STYLE = dict(color="lightgrey", zorder=0, alpha=0.3, s=1)
+DEFAULT_STYLE = {"color": "lightgrey", "zorder": 0, "alpha": 0.3, "s": 1}
 
 DEM_COLORS = ["dimgrey", "purple", "darkcyan", "darkmagenta", "darkgoldenrod"]
 

--- a/src/ivert/plot_results_slope_centrality.py
+++ b/src/ivert/plot_results_slope_centrality.py
@@ -156,7 +156,12 @@ def plot_errors_against_slope_centrality(
         transform=ax1.transAxes,
     )
     txt.set_bbox(
-        dict(facecolor="white", alpha=0.7, edgecolor="white", boxstyle="square,pad=0"),
+        {
+            "facecolor": "white",
+            "alpha": 0.7,
+            "edgecolor": "white",
+            "boxstyle": "square,pad=0",
+        },
     )
 
     coverage_pct = coverage_frac * 100
@@ -244,7 +249,12 @@ def plot_errors_against_slope_centrality(
         transform=ax4.transAxes,
     )
     txt.set_bbox(
-        dict(facecolor="white", alpha=0.7, edgecolor="white", boxstyle="square,pad=0"),
+        {
+            "facecolor": "white",
+            "alpha": 0.7,
+            "edgecolor": "white",
+            "boxstyle": "square,pad=0",
+        },
     )
 
     txt = ax4.text(
@@ -257,7 +267,12 @@ def plot_errors_against_slope_centrality(
         transform=ax4.transAxes,
     )
     txt.set_bbox(
-        dict(facecolor="white", alpha=0.7, edgecolor="white", boxstyle="square,pad=0"),
+        {
+            "facecolor": "white",
+            "alpha": 0.7,
+            "edgecolor": "white",
+            "boxstyle": "square,pad=0",
+        },
     )
 
     fig.tight_layout()

--- a/src/ivert/plot_validation_results.py
+++ b/src/ivert/plot_validation_results.py
@@ -228,12 +228,12 @@ def plot_histograms_and_line(
             transform=ax1.transAxes,
         )
         txt.set_bbox(
-            dict(
-                facecolor="white",
-                alpha=0.85,
-                edgecolor="white",
-                boxstyle="square,pad=0",
-            ),
+            {
+                "facecolor": "white",
+                "alpha": 0.85,
+                "edgecolor": "white",
+                "boxstyle": "square,pad=0",
+            },
         )
 
         # If requested, add the RMSE value to the figure.
@@ -249,12 +249,12 @@ def plot_histograms_and_line(
                 transform=ax1.transAxes,
             )
             txt_std.set_bbox(
-                dict(
-                    facecolor="white",
-                    alpha=0.95,
-                    edgecolor="white",
-                    boxstyle="square,pad=0",
-                ),
+                {
+                    "facecolor": "white",
+                    "alpha": 0.95,
+                    "edgecolor": "white",
+                    "boxstyle": "square,pad=0",
+                },
             )
 
         ax1.text(
@@ -329,12 +329,12 @@ def plot_histograms_and_line(
             transform=ax2.transAxes,
         )
         txt.set_bbox(
-            dict(
-                facecolor="white",
-                alpha=0.85,
-                edgecolor="white",
-                boxstyle="square,pad=0",
-            ),
+            {
+                "facecolor": "white",
+                "alpha": 0.85,
+                "edgecolor": "white",
+                "boxstyle": "square,pad=0",
+            },
         )
 
         # If requested, add the RMSE value to the figure.
@@ -350,12 +350,12 @@ def plot_histograms_and_line(
                 transform=ax2.transAxes,
             )
             txt_std.set_bbox(
-                dict(
-                    facecolor="white",
-                    alpha=0.95,
-                    edgecolor="white",
-                    boxstyle="square,pad=0",
-                ),
+                {
+                    "facecolor": "white",
+                    "alpha": 0.95,
+                    "edgecolor": "white",
+                    "boxstyle": "square,pad=0",
+                },
             )
 
         ax2.text(
@@ -571,7 +571,12 @@ def plot_histogram_and_error_stats_4_panels(
         transform=ax1.transAxes,
     )
     txt.set_bbox(
-        dict(facecolor="white", alpha=0.85, edgecolor="white", boxstyle="square,pad=0"),
+        {
+            "facecolor": "white",
+            "alpha": 0.85,
+            "edgecolor": "white",
+            "boxstyle": "square,pad=0",
+        },
     )
 
     # If requested, as the RMSE value to the figure.
@@ -587,12 +592,12 @@ def plot_histogram_and_error_stats_4_panels(
             transform=ax1.transAxes,
         )
         txt_std.set_bbox(
-            dict(
-                facecolor="white",
-                alpha=0.85,
-                edgecolor="white",
-                boxstyle="square,pad=0",
-            ),
+            {
+                "facecolor": "white",
+                "alpha": 0.85,
+                "edgecolor": "white",
+                "boxstyle": "square,pad=0",
+            },
         )
 
     # Add subplot label "a"

--- a/src/ivert/utils/dem_geom.py
+++ b/src/ivert/utils/dem_geom.py
@@ -36,7 +36,7 @@ def get_dem_reference_frame_from_user_input(
     """
     if crs is None or crs == "":
         crs_obj = None
-    elif isinstance(crs, rasterio.crs.CRS) or isinstance(crs, pyproj.CRS):
+    elif isinstance(crs, (rasterio.crs.CRS, pyproj.CRS)):
         crs_obj = pyproj.CRS(crs)
     else:
         crs_obj = pyproj.CRS.from_user_input(crs)

--- a/src/ivert/utils/parallel_funcs.py
+++ b/src/ivert/utils/parallel_funcs.py
@@ -280,7 +280,7 @@ def process_parallel(
 
     # If this process crashes or is keyboard-interrupted,
     # clean up the tempdirs and running procs, then re-raise the error to be handled elsewhere.
-    except (Exception, KeyboardInterrupt) as e:
+    except (Exception, KeyboardInterrupt):
         # Kill any running processes.
         for rproc in running_procs:
             rproc.kill()
@@ -293,4 +293,4 @@ def process_parallel(
             for fn in running_outfiles:
                 if type(fn) is str and os.path.exists(fn):
                     os.remove(fn)
-        raise e
+        raise

--- a/src/ivert/utils/split_dem.py
+++ b/src/ivert/utils/split_dem.py
@@ -1,4 +1,3 @@
-#!python3
 """Quick utility for splitting a large DEM into sub-segments to ease processing constraints."""
 
 import glob

--- a/src/ivert/utils/traverse_directory.py
+++ b/src/ivert/utils/traverse_directory.py
@@ -31,10 +31,10 @@ def _list_files_recurse(dirname, regex_match=None, depth=-1):
     for entryname in fpath_list:
         try:
             fpath = os.path.join(dirname, entryname)
-        except TypeError as e:
+        except TypeError:
             print("dirname:", dirname)
             print("entryname:", entryname)
-            raise e
+            raise
         if (depth == -1 or depth > 0) and os.path.isdir(fpath):
             file_list.extend(
                 _list_files_recurse(

--- a/src/ivert/validate_dem.py
+++ b/src/ivert/validate_dem.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Created on Tue Jun 22 16:06:21 2021
 
 @author: mmacferrin

--- a/src/ivert/validate_dem.py
+++ b/src/ivert/validate_dem.py
@@ -1178,9 +1178,9 @@ def _compute_photon_overlap(
                 cache_dir=cache_dir,
             )
         )
-    except (ValueError, RuntimeError) as e:
+    except (ValueError, RuntimeError):
         print("Warning: Unable to perform transformation. Using original points.")
-        raise e
+        raise
 
     if exclude_zones:
         exclude_geom = _resolve_exclude_geometry(exclude_zones, dem_epsg_str)

--- a/src/ivert/validate_dem.py
+++ b/src/ivert/validate_dem.py
@@ -1693,7 +1693,7 @@ def _write_validation_outputs(
 
     if verbose:
         print(
-            "{0:,} valid interdecile photon records in {1:,} DEM cells.".format(
+            "{:,} valid interdecile photon records in {:,} DEM cells.".format(
                 results_dataframe["numphotons_intd"].sum(),
                 len(results_dataframe),
             ),
@@ -2032,12 +2032,12 @@ def write_summary_stats_file(
     lines = []
     lines.append(f"Number of DEM cells validated (cells): {len(results_df)}")
     lines.append(
-        "Total number of ground photons used to validate this DEM (photons): {0}".format(
+        "Total number of ground photons used to validate this DEM (photons): {}".format(
             results_df["numphotons_intd"].sum(),
         ),
     )
     lines.append(
-        "Mean number of photons used to validate each cell (photons): {0}".format(
+        "Mean number of photons used to validate each cell (photons): {}".format(
             _format_stat(results_df["numphotons_intd"].mean()),
         ),
     )
@@ -2052,7 +2052,7 @@ def write_summary_stats_file(
     )
 
     lines.append(
-        "Number of cells with bathymetry photons: {0:d}".format(
+        "Number of cells with bathymetry photons: {:d}".format(
             numpy.count_nonzero(results_df["numphotons_bathy"] > 0),
         ),
     )
@@ -2061,7 +2061,7 @@ def write_summary_stats_file(
     # lines.append("% of cells with >0 measured canopy (%): {0}".format((numpy.count_nonzero(results_df.canopy_fraction > 0.0) / len(results_df))*100))
     # lines.append("Mean canopy cover in 'wooded' cells containing >0 canopy (% cover): {0}".format(results_df[results_df["canopy_fraction"] > 0]["canopy_fraction"].mean()*100))
     lines.append(
-        "Mean roughness (stddev. of photon elevations within each cell (m)): {0}".format(
+        "Mean roughness (stddev. of photon elevations within each cell (m)): {}".format(
             _format_stat(results_df["stddev"].mean()),
         ),
     )

--- a/src/ivert/validate_dem_collection.py
+++ b/src/ivert/validate_dem_collection.py
@@ -355,8 +355,8 @@ def validate_list_of_dems(
                 print(f"Skipping {os.path.basename(dem_path)} due to memory error.")
             continue
 
-        except KeyboardInterrupt as e:
-            raise e
+        except KeyboardInterrupt:
+            raise
 
         except Exception:
             if verbose:

--- a/src/ivert/vdatum_lookup.py
+++ b/src/ivert/vdatum_lookup.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """ivert.vdatum_lookup
 ~~~~~~~~~~~~~~~~~~~
 Translate common vertical datum names to formal EPSG code strings.


### PR DESCRIPTION
First pass at trimming the `[tool.ruff.lint] ignore` list in `pyproject.toml`, per #40. This removes eight rules from the ignore list and fixes every error they raise. The ignore list goes from 138 to 130 entries.

Rules were chosen by running `ruff check src --extend-select ALL --statistics` to get the real violation count behind each ignored rule, then picking the ones whose fixes are mechanical and carry no behavior change.

### Rules enabled

| Commit | Rule | Change |
| --- | --- | --- |
| `b61771e` | `C408` unnecessary-collection-call | 20 `dict(...)` calls rewritten as dict literals |
| `b61771e` | `TRY201` verbose-raise | 5 `raise e` inside `except` blocks replaced with bare `raise`, plus the 5 now-unused `as e` bindings that `F841` flagged as a result |
| `4d3f9fe` | `RSE102` unnecessary-paren-on-raise-exception | 2 `raise click.Abort()` → `raise click.Abort` |
| `2c2fa15` | `SIM101` duplicate-isinstance-call | 2 `isinstance(x, A) or isinstance(x, B)` pairs merged into tuple form |
| `a682718` | `FURB110` if-exp-instead-of-or-operator | 2 `os.path.dirname(x) if os.path.dirname(x) else "."` → `os.path.dirname(x) or "."`, which also avoids calling `dirname` twice |
| `56a6897` | `RUF005` collection-literal-concatenation | 2 sequence concatenations rewritten as unpacking |
| `c657d63` | `UP030` format-literals | 5 `str.format()` calls in `validate_dem.py` switched from explicit positional indices to implicit ones |
| `3d2e7c2` | `EXE001` shebang-not-executable | 7 vestigial shebang lines removed |

### Notes

**`EXE001`** — the seven affected modules are not executed directly: the package installs a single `ivert` console script (`ivert = "ivert.cli:ivert_cli"`), and everything else is imported or run through the interpreter. Removing the shebangs keeps all file modes at 644 rather than adding execute bits to library modules. It also retires the `#!python3` line in `utils/split_dem.py`, which was not a valid interpreter path and would have failed if the file were ever executed directly.

**`SIM101`** — the `datetime` check in `icesat2_database_v2.py` is kept as `isinstance(date, (datetime.datetime, datetime.date))`. Since `datetime.datetime` subclasses `datetime.date`, the second member is technically redundant, but preserving it keeps this a pure lint fix rather than a semantic one.

**`B905`** (zip-without-explicit-strict, 15 sites) was considered and deliberately left out. Unlike the rules above it is not mechanical — each call site needs a decision about whether the zipped iterables are guaranteed equal-length, and `strict=True` converts today's silent truncation into a `ValueError`. That deserves its own pass.

### Verification

- `ruff check src` and `ruff format --check src` pass, and `prek run --all-files` passes, at every commit in the branch.
- `ivert --help` runs, and all touched modules import cleanly. Two modules could only be checked with `py_compile` for environment reasons unrelated to this branch: `validate_dem.py` needs `transformez`, which is not installed locally, and `plot_results_slope_centrality.py` imports a nonexistent `import_parent_dir` module (pre-existing on `main`, confirmed by checking out `main` and reproducing the same failure).
- Module docstrings confirmed intact after the shebang removals.
- The rewritten `.format()` calls and unpacking expressions were spot-checked to produce identical output.

`pytest` is not installed in the local environment, so the test suite was not run.

### Remaining work

This is one step toward #40, not the whole thing. The largest remaining block is the `PTH*` cluster (~380 hits across 20 rules), which is a genuine `os.path` → `pathlib` refactor rather than a sweep. Other sizable groups still ignored include `ANN*`, `ERA001`, `E501`, `T201`, and `EM101`/`EM102`.

Part of #40.
