### PR TITLE
Enable nine more previously-ignored ruff lint rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,6 @@ ignore = [
     "BLE001",   # blind-except
     "C401",     # unnecessary-generator-set
     "C403",     # unnecessary-list-comprehension-set
-    "C404",     # unnecessary-list-comprehension-dict
     "C414",     # unnecessary-double-cast-or-process
     "C901",     # complex-structure
     "D100",     # undocumented-public-module
@@ -110,7 +109,6 @@ ignore = [
     "N806",     # non-lowercase-variable-in-function
     "PD002",    # pandas-use-of-inplace-argument
     "PD011",    # pandas-use-of-dot-values
-    "PERF401",  # vmanual-list-comprehension
     "PLC0415",  # import-outside-top-level
     "PLR0912",  # too-many-branches
     "PLR0913",  # too-many-arguments
@@ -139,14 +137,10 @@ ignore = [
     "PTH204",   # os-path-getmtime
     "PTH207",   # glob
     "PTH208",   # os-listdir
-    "RET503",   # implicit-return
     "RET504",   # unnecessary-assign
     "RUF001",   # ambiguous-unicode-character-string
     "RUF002",   # ambiguous-unicode-character-docstring
-    "RUF012",   # mutable-class-default
-    "RUF013",   # implicit-optional
     "RUF015",   # unnecessary-iterable-allocation-for-first-element
-    "RUF059",   # unused-unpacked-variable
     "S101",     # assert
     "S110",     # try-except-pass
     "S301",     # suspicious-pickle-usage
@@ -156,8 +150,6 @@ ignore = [
     "SIM102",   # collapsible-if
     "SIM105",   # suppressible-exception
     "SIM115",   # open-file-with-context-handler
-    "SIM118",   # in-dict-keys
-    "SIM212",   # if-expr-with-twisted-arms
     "SLF001",   # private-member-access
     "T201",     # print
     "TD002",    # missing-todo-author
@@ -165,5 +157,4 @@ ignore = [
     "TRY003",   # raise-vanilla-args
     "TRY004",   # type-check-without-type-error
     "TRY300",   # try-consider-else
-    "UP031",    # printf-string-formatting
 ]

--- a/src/ivert/cli.py
+++ b/src/ivert/cli.py
@@ -380,9 +380,7 @@ def options_list(details):
     from ivert.utils.configfile import Config, parse_option_descriptions
 
     config = Config()
-    keys = [
-        k for k in config._config["DEFAULT"].keys() if k not in _OPTIONS_EXCLUDED_KEYS
-    ]
+    keys = [k for k in config._config["DEFAULT"] if k not in _OPTIONS_EXCLUDED_KEYS]
 
     if not keys:
         click.echo("No configurable settings found.")
@@ -1502,10 +1500,11 @@ def _cache_dir():
 
 def _fmt_size(nbytes):
     """Format a byte count as a human-readable string."""
-    for unit in ("B", "KB", "MB", "GB", "TB"):
-        if nbytes < 1024 or unit == "TB":
+    for unit in ("B", "KB", "MB", "GB"):
+        if nbytes < 1024:
             return f"{nbytes:.1f} {unit}"
         nbytes /= 1024
+    return f"{nbytes:.1f} TB"
 
 
 @ivert_cli.group("cache", invoke_without_command=True)

--- a/src/ivert/export_vector.py
+++ b/src/ivert/export_vector.py
@@ -97,7 +97,10 @@ def detect_nc_kind(nc_path: str) -> str | None:
 # ---------------------------------------------------------------------------
 # Core conversion
 # ---------------------------------------------------------------------------
-def nc_to_geodataframe(nc_path: str, classes: list = None) -> geopandas.GeoDataFrame:
+def nc_to_geodataframe(
+    nc_path: str,
+    classes: list | None = None,
+) -> geopandas.GeoDataFrame:
     """Read a single .nc granule file and return a GeoDataFrame.
 
     Parameters

--- a/src/ivert/icesat2_database_v2.py
+++ b/src/ivert/icesat2_database_v2.py
@@ -5,6 +5,7 @@ import logging
 import os
 import re
 import shutil
+from typing import ClassVar
 
 import dateparser
 import fetchez
@@ -417,7 +418,7 @@ class IS2Database:
     # to "ellipsoid" for any value it doesn't recognize (it does not raise), so
     # passing an EPSG code straight through would be a silent no-op rather than
     # an error -- always go through this lookup instead.
-    _EPSG_TO_GLOBATO_VERTICAL_DATUM = {
+    _EPSG_TO_GLOBATO_VERTICAL_DATUM: ClassVar[dict[str, str]] = {
         "EPSG:4979": "ellipsoid",
         "EPSG:3855": "geoid",
     }
@@ -498,9 +499,7 @@ class IS2Database:
             use_external_masks=use_external_masks,
         )
 
-        chunks = []
-        for chunk in stream:
-            chunks.append(pandas.DataFrame(chunk))
+        chunks = [pandas.DataFrame(chunk) for chunk in stream]
 
         if not chunks:
             return None

--- a/src/ivert/plot_results_slope_centrality.py
+++ b/src/ivert/plot_results_slope_centrality.py
@@ -45,9 +45,7 @@ def add_lat_lons(df):
 def get_slopes(df, files_dirname):
     fnames = [os.path.join(files_dirname, fn) for fn in df.filename.unique()]
     slope_fnames = [fn.replace("_results.h5", "_slope.tif") for fn in fnames]
-    fnames_dict = dict(
-        [(os.path.basename(fn), sfn) for fn, sfn in zip(fnames, slope_fnames)],
-    )
+    fnames_dict = {os.path.basename(fn): sfn for fn, sfn in zip(fnames, slope_fnames)}
 
     fn_array_dict = {}
     slopes = numpy.empty((len(df),), dtype=float)

--- a/src/ivert/utils/query_yes_no.py
+++ b/src/ivert/utils/query_yes_no.py
@@ -19,7 +19,7 @@ def query_yes_no(question: str, default: str = "yes") -> bool:
     elif default.strip().lower() in ("no", "n"):
         prompt = " [y/N] "
     else:
-        raise ValueError("invalid default answer: '%s'" % default)
+        raise ValueError(f"invalid default answer: '{default}'")
 
     while True:
         sys.stdout.write(question + prompt)
@@ -45,4 +45,4 @@ def interpret_yes_no(input_str: str) -> bool:
     if instr[0] in ("n", "f"):
         return False
     # Anything else is invalid
-    raise ValueError("invalid boolean input: '%s'" % input_str)
+    raise ValueError(f"invalid boolean input: '{input_str}'")

--- a/src/ivert/validate_dem.py
+++ b/src/ivert/validate_dem.py
@@ -1728,7 +1728,7 @@ def _write_validation_outputs(
             shared_ret_values["empty_results_filename"] = empty_results_filename
         return files_to_export
 
-    base, ext = os.path.splitext(results_dataframe_file)
+    _base, ext = os.path.splitext(results_dataframe_file)
     ext = ext.lower().strip()
     if ext in (".txt", ".csv"):
         results_dataframe.to_csv(results_dataframe_file)
@@ -2463,7 +2463,7 @@ def main(
         output_dir=output_dir,
         classes=classes_list,
         dem_vertical_datum=input_vdatum,
-        interim_data_dir=(None if not datadir else datadir),
+        interim_data_dir=(datadir or None),
         overwrite=overwrite,
         delete_datafiles=delete_datafiles,
         plot_results=plot_results,


### PR DESCRIPTION
Second pass at trimming the `[tool.ruff.lint] ignore` list in `pyproject.toml`, following #62. This removes nine more rules and fixes the ten errors they raise. The ignore list goes from 130 to 121 entries.

As before, rules were chosen by running `ruff check src --extend-select ALL --statistics` to get the real violation count behind each ignored rule, then picking those whose fixes are mechanical and carry no behavior change.

### Rules enabled

| Rule | Sites | Change |
| --- | --- | --- |
| `C404` unnecessary-list-comprehension-dict | 1 | `dict([(k, v), ...])` rewritten as a dict comprehension |
| `PERF401` manual-list-comprehension | 1 | append loop replaced with a list comprehension |
| `RET503` implicit-return | 1 | `_fmt_size()` restructured so its final return is reachable |
| `RUF012` mutable-class-default | 1 | mutable class attribute annotated as `ClassVar[dict[str, str]]` |
| `RUF013` implicit-optional | 1 | `classes: list = None` spelled as `classes: list \| None = None` |
| `RUF059` unused-unpacked-variable | 1 | unused unpacked `base` renamed to `_base` |
| `SIM118` in-dict-keys | 1 | config section iterated directly rather than via `.keys()` |
| `SIM212` if-expr-with-twisted-arms | 1 | `None if not datadir else datadir` → `datadir or None` |
| `UP031` printf-string-formatting | 2 | percent-format strings replaced with f-strings |

### Notes

**`RET503`** — `_fmt_size()` iterates `("B", "KB", "MB", "GB", "TB")` and returns when `nbytes < 1024 or unit == "TB"`, so the loop can never fall through and ruff's literal fix would have appended an unreachable `return None`. Instead the loop now covers `("B", "KB", "MB", "GB")` with the `TB` case returned explicitly afterward. The two forms were compared across 11 magnitudes from `0` to petabyte-scale and produce identical output for every input.

**`RUF059`** — the line `base, ext = os.path.splitext(results_dataframe_file)` appears three times in `validate_dem.py` (lines 967, 1327, 1731). The first two use `base` on the following line; only line 1731 leaves it unused, and only that one is renamed.

**`SIM212`** — ruff's suggested fix is `datadir if datadir else None`, which would immediately violate `FURB110` (enabled in #62). The `or` form satisfies both rules.

**`RUF012`** — adds `from typing import ClassVar` to `icesat2_database_v2.py`. The annotation is purely declarative; the attribute remains an ordinary class-level dict at runtime.

**`B905`** (zip-without-explicit-strict, 15 sites) is again deliberately left out. It is the one remaining low-count rule that is not mechanical: each call site needs a decision about whether the zipped iterables are guaranteed equal-length, and `strict=True` converts today's silent truncation into a `ValueError`. It deserves its own pass.

### Verification

- `ruff check src`, `ruff format --check src`, and `prek run --all-files` all pass.
- `ivert --help` and `ivert options` run; all touched modules import cleanly.
- Behavior spot-checks beyond the linter: `_fmt_size` old vs. new compared across 11 input magnitudes (no mismatches); `list(section) == list(section.keys())` confirmed against the real config for the `SIM118` change; `SIM212` equivalence checked for `""`, `None`, a path, and `"."`; the `ClassVar` dict confirmed still readable with correct values; both rewritten `ValueError` messages confirmed to render as before.
- Two modules could only be checked with `py_compile`, for environment reasons unrelated to this branch: `validate_dem.py` needs `transformez`, which is not installed locally, and `plot_results_slope_centrality.py` imports a nonexistent `import_parent_dir` module (pre-existing on `main`).

`pytest` is not installed in the local environment, so the test suite was not run.

### Remaining work

Still one step toward #40, not the whole thing. The largest remaining block is the `PTH*` cluster (~380 hits across 20 rules), a genuine `os.path` → `pathlib` refactor rather than a sweep. Other sizable groups still ignored include `ANN*`, `ERA001`, `E501`, `T201`, and `EM101`/`EM102`.

Part of #40.
